### PR TITLE
Add some initial styling to the confirmation page 

### DIFF
--- a/app/assets/images/icons/tick-white.svg
+++ b/app/assets/images/icons/tick-white.svg
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg width="449px" height="343px" viewBox="0 0 449 343" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:sketch="http://www.bohemiancoding.com/sketch/ns">
+    <defs></defs>
+    <g id="Page-1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd" sketch:type="MSPage">
+        <g id="tick" sketch:type="MSLayerGroup" fill="#FFFFFF">
+            <g id="check" sketch:type="MSShapeGroup">
+                <path d="M142.8,270.85 L35.7,163.75 L0,199.45 L142.8,342.25 L448.8,36.25 L413.1,0.55 L142.8,270.85 Z" id="Shape"></path>
+            </g>
+        </g>
+    </g>
+</svg>

--- a/app/assets/stylesheets/moj/_typography.scss
+++ b/app/assets/stylesheets/moj/_typography.scss
@@ -32,6 +32,7 @@ header.main-header {
 .confirmation-tick {
   width: 36px;
   height: 36px;
+  margin-right: $gutter-half;
 }
 
 

--- a/app/views/correspondence/confirmation.html.slim
+++ b/app/views/correspondence/confirmation.html.slim
@@ -1,1 +1,12 @@
-h1 Thank you
+.confirmation-header
+  h1.page-title.bold-large
+    object type='image/svg+xml' data=image_path('icons/tick-white.svg') class="confirmation-tick"
+    | Thank you
+  .bold-medium
+    | Your message has been sent
+
+  .normal
+    | and we will reply shortly.
+
+.button-holder
+  = link_to "Finish",root_path, {role: 'button', class: 'button-secondary'}

--- a/spec/features/send_correspondence_spec.rb
+++ b/spec/features/send_correspondence_spec.rb
@@ -19,6 +19,8 @@ feature 'A member of the public makes an FOI request' do
     fill_in 'Message', with: @text
     click_button 'Send'
     expect(page).to have_content('Thank you')
+    click_link 'Finish'
+    expect(page.current_path).to eq root_path
   end
 
   scenario 'Without supplying a name, email address, email confirmation or message' do


### PR DESCRIPTION
- Add some basic eye-candy to the confirmation page
- Adds a means for users to return to the home page