### PR TITLE
email out of process with sidekiq

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,9 @@
 /db/*.sqlite3
 /db/*.sqlite3-journal
 
+* ignore dumped file
+/dump.rdb
+
 # Ignore all logfiles and tempfiles.
 /log/*
 /tmp/*

--- a/Gemfile
+++ b/Gemfile
@@ -12,6 +12,7 @@ gem 'jquery-rails'
 gem 'puma', '~> 3.0'
 gem 'rails', '~> 5.0.0'
 gem 'sass-rails', '~> 5.0'
+gem 'sidekiq'
 gem 'slim-rails', '~> 3.1'
 gem 'susy',	                  '~> 2.2.12'
 # Turbolinks makes navigating your web application faster. Read more: https://github.com/turbolinks/turbolinks

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -56,6 +56,23 @@ GEM
       rack (>= 1.0.0)
       rack-test (>= 0.5.4)
       xpath (~> 2.0)
+    celluloid (0.17.3)
+      celluloid-essentials
+      celluloid-extras
+      celluloid-fsm
+      celluloid-pool
+      celluloid-supervision
+      timers (>= 4.1.1)
+    celluloid-essentials (0.20.5)
+      timers (>= 4.1.1)
+    celluloid-extras (0.20.5)
+      timers (>= 4.1.1)
+    celluloid-fsm (0.20.5)
+      timers (>= 4.1.1)
+    celluloid-pool (0.20.5)
+      timers (>= 4.1.1)
+    celluloid-supervision (0.20.6)
+      timers (>= 4.1.1)
     coderay (1.1.1)
     coffee-rails (4.2.1)
       coffee-script (>= 2.2.0)
@@ -68,6 +85,7 @@ GEM
     config (1.2.1)
       activesupport (>= 3.0)
       deep_merge (~> 1.0, >= 1.0.1)
+    connection_pool (2.2.0)
     debug_inspector (0.0.2)
     deep_merge (1.0.1)
     diff-lcs (1.2.5)
@@ -116,6 +134,7 @@ GEM
       guard (~> 2.1)
       guard-compat (~> 1.1)
       rspec (>= 2.99.0, < 4.0)
+    hitimes (1.2.4)
     http_parser.rb (0.6.0)
     i18n (0.7.0)
     jbuilder (2.5.0)
@@ -125,6 +144,7 @@ GEM
       rails-dom-testing (>= 1, < 3)
       railties (>= 4.2.0)
       thor (>= 0.14, < 2.0)
+    json (1.8.3)
     listen (3.0.8)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
@@ -193,6 +213,9 @@ GEM
     rb-fsevent (0.9.7)
     rb-inotify (0.9.7)
       ffi (>= 0.5.0)
+    redis (3.3.0)
+    redis-namespace (1.5.2)
+      redis (~> 3.0, >= 3.0.4)
     rspec (3.5.0)
       rspec-core (~> 3.5.0)
       rspec-expectations (~> 3.5.0)
@@ -222,6 +245,12 @@ GEM
       sprockets-rails (>= 2.0, < 4.0)
       tilt (>= 1.1, < 3)
     shellany (0.0.1)
+    sidekiq (3.5.4)
+      celluloid (~> 0.17.2)
+      connection_pool (~> 2.2, >= 2.2.0)
+      json (~> 1.0)
+      redis (~> 3.2, >= 3.2.1)
+      redis-namespace (~> 1.5, >= 1.5.2)
     slim (3.0.7)
       temple (~> 0.7.6)
       tilt (>= 1.3.3, < 2.1)
@@ -247,6 +276,8 @@ GEM
     thor (0.19.1)
     thread_safe (0.3.5)
     tilt (2.0.5)
+    timers (4.1.1)
+      hitimes
     turbolinks (5.0.0)
       turbolinks-source (~> 5)
     turbolinks-source (5.0.0)
@@ -290,6 +321,7 @@ DEPENDENCIES
   rails_12factor
   rspec-rails (~> 3.4)
   sass-rails (~> 5.0)
+  sidekiq
   slim-rails (~> 3.1)
   spring
   spring-watcher-listen (~> 2.0.0)

--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,2 @@
+worker: bundle exec sidekiq
+redis: redis-server

--- a/app/controllers/correspondence_controller.rb
+++ b/app/controllers/correspondence_controller.rb
@@ -8,11 +8,9 @@ class CorrespondenceController < ApplicationController
     @correspondence = Correspondence.new(correspondence_params)
 
     if @correspondence.valid?
-      # TODO: create and send email
-      CorrespondenceMailer.new_correspondence(@correspondence).deliver_now
+      EmailCorrespondenceJob.perform_later(YAML.dump(@correspondence))
       render 'correspondence/confirmation'
     else
-      # TODO: show errors
       render :new
     end
   end

--- a/app/jobs/email_correspondence_job.rb
+++ b/app/jobs/email_correspondence_job.rb
@@ -1,7 +1,5 @@
 class EmailCorrespondenceJob < ApplicationJob
 
-  require 'sidekiq/API'
-
   queue_as :mailers
 
   def perform(correspondence_yaml)

--- a/app/jobs/email_correspondence_job.rb
+++ b/app/jobs/email_correspondence_job.rb
@@ -1,0 +1,12 @@
+class EmailCorrespondenceJob < ApplicationJob
+
+  require 'sidekiq/API'
+
+  queue_as :mailers
+
+  def perform(correspondence_yaml)
+    correspondence = YAML.load(correspondence_yaml)
+    CorrespondenceMailer.new_correspondence(correspondence).deliver_now
+  end
+
+end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -26,10 +26,9 @@ Rails.application.configure do
     config.cache_store = :null_store
   end
 
-  # Don't care if the mailer can't send.
-  config.action_mailer.raise_delivery_errors = true
-
   config.action_mailer.perform_caching = false
+  config.active_job.queue_adapter = :sidekiq
+  config.action_mailer.delivery_method = :smtp
 
   # Print deprecation notices to the Rails logger.
   config.active_support.deprecation = :log

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -26,6 +26,9 @@ Rails.application.configure do
     config.cache_store = :null_store
   end
 
+  # Do care if the mailer can't send.
+  config.action_mailer.raise_delivery_errors = true
+  
   config.action_mailer.perform_caching = false
   config.active_job.queue_adapter = :sidekiq
   config.action_mailer.delivery_method = :smtp

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -28,6 +28,7 @@ Rails.application.configure do
   # `config.assets.precompile` and `config.assets.version` have moved to config/initializers/assets.rb
 
   config.action_mailer.delivery_method = :smtp
+  config.active_job.queue_adapter = :sidekiq
 # SMTP settings for gmail
 
   # Enable serving of images, stylesheets, and JavaScripts from an asset server.

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -33,7 +33,8 @@ Rails.application.configure do
   # The :test delivery method accumulates sent emails in the
   # ActionMailer::Base.deliveries array.
   config.action_mailer.delivery_method = :test
-
+  
+  config.active_job.queue_adapter = :test
   # Print deprecation notices to the stderr.
   config.active_support.deprecation = :stderr
 

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -1,0 +1,6 @@
+---
+:concurrency: 25
+:pidfile: ./tmp/pids/sidekiq.pid
+:logfile: ./log/sidekiq.log
+:queues:
+  - mailers

--- a/spec/controllers/correspondence_controller_spec.rb
+++ b/spec/controllers/correspondence_controller_spec.rb
@@ -32,9 +32,13 @@ RSpec.describe CorrespondenceController, type: :controller do
         expect(response).to render_template(:confirmation)
       end
 
-      it 'sends #new_correspondence to CorrespondenceMailer' do
-        expect_any_instance_of(CorrespondenceMailer).to receive(:new_correspondence)
-        post :create, params: params
+      it 'sends #perorm_later to the EmailCorrespondenceJob' do
+        expect(EmailCorrespondenceJob).to receive(:perform_later)
+        post :create, params: params        
+      end
+
+      it 'and a job is enqueued' do
+        expect { post :create, params: params }.to have_enqueued_job(EmailCorrespondenceJob)
       end
     end
 

--- a/spec/jobs/email_correspondence_job_spec.rb
+++ b/spec/jobs/email_correspondence_job_spec.rb
@@ -1,0 +1,19 @@
+require 'rails_helper'
+
+RSpec.describe EmailCorrespondenceJob, type: :job do
+  
+  let(:correspondence) { build(:correspondence) }
+
+  describe '#perform_later' do
+
+    before do
+      @correspondence_yaml = YAML.dump(correspondence)
+      ActiveJob::Base.queue_adapter = :test
+    end
+
+    it 'accepts a serialised object and adds a job to the queue' do
+      expect { EmailCorrespondenceJob.perform_later(@correspondence_yaml) }.to have_enqueued_job(EmailCorrespondenceJob)
+    end
+  end
+
+end


### PR DESCRIPTION
- send emails out of process
- use Sidekiq for now
- YAML.dump is required because models can only be used if they're persisted
- using foreman to start both redis and Sidekiq

@jaikoo : please can you take a quick look at this too?