### PR TITLE
Procfile

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,1 @@
+REDIS_URL=redis://localhost:6379

--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,5 @@ config/settings.local.yml
 config/settings/*.local.yml
 config/environments/*.local.yml
 config/secrets.yml
+
+.env

--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,2 @@
-worker: bundle exec sidekiq
-redis: redis-server
+web: bundle exec puma -C config/puma.rb
+worker: bundle exec sidekiq -C config/sidekiq.yml

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -21,7 +21,7 @@ environment ENV.fetch("RAILS_ENV") { "development" }
 # Workers do not work on JRuby or Windows (both of which do not support
 # processes).
 #
-# workers ENV.fetch("WEB_CONCURRENCY") { 2 }
+workers ENV.fetch("WEB_CONCURRENCY") { 2 }
 
 # Use the `preload_app!` method when specifying a `workers` number.
 # This directive tells Puma to first boot the application and load code
@@ -39,9 +39,9 @@ environment ENV.fetch("RAILS_ENV") { "development" }
 # or connections that may have been created at application boot, Ruby
 # cannot share connections between processes.
 #
-# on_worker_boot do
-#   ActiveRecord::Base.establish_connection if defined?(ActiveRecord)
-# end
+on_worker_boot do
+  ActiveRecord::Base.establish_connection if defined?(ActiveRecord)
+end
 
 # Allow puma to be restarted by `rails restart` command.
 plugin :tmp_restart

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -1,6 +1,5 @@
 ---
 :concurrency: 25
-:pidfile: ./tmp/pids/sidekiq.pid
 :logfile: ./log/sidekiq.log
 :queues:
   - mailers


### PR DESCRIPTION
I've cleaned up the Procfile and moved the redis process startup out of the Procfile too. In order to test this locally outside of docker you need to rename .env.example to .env so that it'll be picked up via Foreman locally. 

Redis in this instance will have to be started manually and separately. Later I'm going to setup another pull request so that Redis is started as a service in Docker Compose.

Thanks