### PR TITLE
Format type and topic

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,1 @@
+REDIS_URL=redis://localhost:6379

--- a/.env.example
+++ b/.env.example
@@ -1,1 +1,0 @@
-REDIS_URL=redis://localhost:6379

--- a/app/views/correspondence/new.html.slim
+++ b/app/views/correspondence/new.html.slim
@@ -11,11 +11,11 @@
 
 	.form-group
 	    = f.label :type, 'Type of correspondence', class: 'form-label'
-	    = f.collection_select :type, Settings.correspondence_types, :underscore, :humanize, {class:'form-control'}
+	    = f.collection_select :type, Settings.correspondence_types, :underscore, :humanize, {}, {class:'form-control'}
 
 	.form-group
 	    = f.label :topic, class: 'form-label'
-	    = f.collection_select :topic, Settings.correspondence_topics, :underscore, :humanize, {class:'form-control'}
+	    = f.collection_select :topic, Settings.correspondence_topics, :underscore, :humanize, {}, {class:'form-control'}
 
     = f.text_area :message
 

--- a/app/views/correspondence/new.html.slim
+++ b/app/views/correspondence/new.html.slim
@@ -11,11 +11,11 @@
 
 	.form-group
 	    = f.label :type, 'Type of correspondence', class: 'form-label'
-	    = f.select :type, Settings.correspondence_types, {}, {class:'form-control'}
+	    = f.collection_select :type, Settings.correspondence_types, :underscore, :humanize, {class:'form-control'}
 
 	.form-group
 	    = f.label :topic, class: 'form-label'
-	    = f.select :topic, Settings.correspondence_topics, {},{ class:'form-control'}
+	    = f.collection_select :topic, Settings.correspondence_topics, :underscore, :humanize, {class:'form-control'}
 
     = f.text_area :message
 

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1,11 +1,11 @@
 correspondence_types:
-  - Freedom of Information Request
-  - Treat Official
+  - freedom_of_information_request
+  - treat_official
 
 correspondence_topics:
-  - Prisons
-  - Courts
-  - Legal Aid
-  - Other
-  - More than one
-  - I don't know
+  - prisons
+  - courts
+  - legal_aid
+  - other
+  - more_than_one
+  - do_not_know

--- a/spec/controllers/correspondence_controller_spec.rb
+++ b/spec/controllers/correspondence_controller_spec.rb
@@ -9,8 +9,8 @@ RSpec.describe CorrespondenceController, type: :controller do
         name: external_user.name,
         email: external_user.email,
         email_confirmation: external_user.email,
-        type: "Freedom of Information Request",
-        topic: "Prisons",
+        type: "freedom_of_information_request",
+        topic: "prisons",
         message: Faker::Lorem.paragraph[1]
       }
     }

--- a/spec/factories/correspondence.rb
+++ b/spec/factories/correspondence.rb
@@ -3,8 +3,8 @@ FactoryGirl.define do
     name { Faker::Name.name }
     email { Faker::Internet.email }
     email_confirmation { email }
-    type 'Freedom of Information Request'
-    topic 'Prisons'
+    type 'freedom_of_information_request'
+    topic 'prisons'
     message { Faker::Lorem.paragraph(1) }
   end
 end

--- a/spec/features/send_correspondence_spec.rb
+++ b/spec/features/send_correspondence_spec.rb
@@ -14,7 +14,7 @@ feature 'A member of the public makes an FOI request' do
     fill_in 'Name', with: @name
     fill_in 'Email', with: @email
     fill_in 'Email confirmation', with: @email
-    page.find(:select, text: 'Freedom').select('Freedom of Information Request')
+    page.find(:select, text: 'Freedom').select('Freedom of information request')
     page.find(:select, text: 'Prisons').select('Prisons')
     fill_in 'Message', with: @text
     click_button 'Send'
@@ -25,7 +25,7 @@ feature 'A member of the public makes an FOI request' do
 
   scenario 'Without supplying a name, email address, email confirmation or message' do
     visit 'correspondence/new'
-    page.find(:select, text: 'Freedom').select('Freedom of Information Request')
+    page.find(:select, text: 'Freedom').select('Freedom of information request')
     page.find(:select, text: 'Prisons').select('Prisons')
     click_button 'Send'
     @error_messages.each { |error_message| expect(page).to have_content(error_message) }


### PR DESCRIPTION
- format type and topic to snakecase
- type will be used to select the correct internal email address, as in ENV['type_of_correspondence']
- topic changed for consistency
- changed to collection_select so that we can format the items for human readability in an elegant way