### PR TITLE
reduce redis concurrency to 20

### DIFF
--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -1,5 +1,5 @@
 ---
-:concurrency: 25
+:concurrency: 20
 :logfile: ./log/sidekiq.log
 :queues:
   - mailers


### PR DESCRIPTION
On the free heroku redis instance we can only support a max of 20 connections, when previously the limit was set to 25. This fix should stop the max connection limit reached redis errors.