### PR TITLE
Removed turbolinks so <a> work as expected

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,8 +16,6 @@ gem 'sass-rails', '~> 5.0'
 gem 'sidekiq'
 gem 'slim-rails', '~> 3.1'
 gem 'susy',	                  '~> 2.2.12'
-# Turbolinks makes navigating your web application faster. Read more: https://github.com/turbolinks/turbolinks
-gem 'turbolinks', '~> 5'
 gem 'uglifier', '>= 1.3.0'
 # Use Redis adapter to run Action Cable in production
 # gem 'redis', '~> 3.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -271,9 +271,6 @@ GEM
     thor (0.19.1)
     thread_safe (0.3.5)
     tilt (2.0.5)
-    turbolinks (5.0.0)
-      turbolinks-source (~> 5)
-    turbolinks-source (5.0.0)
     tzinfo (1.2.2)
       thread_safe (~> 0.1)
     uglifier (3.0.0)
@@ -321,7 +318,6 @@ DEPENDENCIES
   spring
   spring-watcher-listen (~> 2.0.0)
   susy (~> 2.2.12)
-  turbolinks (~> 5)
   tzinfo-data
   uglifier (>= 1.3.0)
   web-console

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -12,5 +12,4 @@
 //
 //= require jquery
 //= require jquery_ujs
-//= require turbolinks
 //= require_tree .


### PR DESCRIPTION
- <a> were behaving oddly, submit an invalid form and then click on the summary error messages at the top. It should take you to the invalid field.