### PR TITLE
use entire line from Faker::Lorem.paragraph

### DIFF
--- a/spec/controllers/correspondence_controller_spec.rb
+++ b/spec/controllers/correspondence_controller_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe CorrespondenceController, type: :controller do
         email_confirmation: external_user.email,
         type: "freedom_of_information_request",
         topic: "prisons",
-        message: Faker::Lorem.paragraph[1]
+        message: Faker::Lorem.paragraph(1)
       }
     }
   end


### PR DESCRIPTION
- two tests were failing intermittently (~1 in 100)

- cause: Faker::Lorem.pragraph[1] returns the second character from #paragraph, which can sometimes be a space if, for example, the paragraph starts with 'A' (i.e. any single character word).  This caused the message validation to fail and our test expectation for posting to #create was not met.

- solution: Faker::Lorem.paragraph(1) returns one whole sentence.  Validation now OK.