### PR TITLE
Log correspondences when they're submitted.

### DIFF
--- a/app/controllers/correspondence_controller.rb
+++ b/app/controllers/correspondence_controller.rb
@@ -9,6 +9,15 @@ class CorrespondenceController < ApplicationController
 
     if @correspondence.valid?
       EmailCorrespondenceJob.perform_later(YAML.dump(@correspondence))
+      Rails.configuration.correspondence_logger.info(
+        [
+          DateTime.now.to_s,
+          @correspondence.name,
+          @correspondence.email,
+          @correspondence.topic,
+          @correspondence.message.gsub('\\', '\\\\').gsub("\n", '\\n').gsub("\r", '\\r')
+        ].join("\t")
+      )
       render 'correspondence/confirmation'
     else
       render :new

--- a/config/initializers/correspondence_logger.rb
+++ b/config/initializers/correspondence_logger.rb
@@ -1,0 +1,3 @@
+Rails.application.configure do
+  config.correspondence_logger = ActiveSupport::Logger.new('correspondence.log')
+end


### PR DESCRIPTION
This is a rushed implementation of logging correspondence
information. We still need to add tests, ensure this is logging to the
right directory and that it works in multi-process environments.