### PR TITLE
254 - Remove duplication of 'foreman' gem in the Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,7 +23,6 @@ gem 'uglifier', '>= 1.3.0'
 # gem 'bcrypt', '~> 3.1.7'
 # Use Capistrano for deployment
 # gem 'capistrano-rails', group: :development
-gem "foreman"
 
 group :test do
   gem 'capybara'
@@ -45,7 +44,7 @@ end
 
 group :development do
   # Access an IRB console on exception pages or by using <%= console %> anywhere in the code.
-  gem 'foreman'
+  gem 'foreman', '~> 0.82.0'
   gem 'guard-livereload', '>= 2.5.2'
   gem 'guard-rspec'
   gem 'guard-rubocop'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -323,7 +323,7 @@ DEPENDENCIES
   config
   factory_girl_rails
   faker
-  foreman
+  foreman (~> 0.82.0)
   govuk_elements_form_builder!
   govuk_elements_rails (>= 1.2.1)
   govuk_frontend_toolkit (>= 4.13.0)


### PR DESCRIPTION
I removed the Global instance which was added by JC https://github.com/ministryofjustice/correspondence_tool_public/pull/55/files#diff-8b7db4d5cc4b8f6dc8feb7030baa2478R26

I dont think we use foreman in production only for dev env