### PR TITLE
First iteration requires email_confirmation

### DIFF
--- a/app/controllers/correspondence_controller.rb
+++ b/app/controllers/correspondence_controller.rb
@@ -46,6 +46,7 @@ class CorrespondenceController < ApplicationController
     params.require(:correspondence).permit(
       :name,
       :email,
+      :email_confirmation,
       :topic,
       :message
       ) 

--- a/app/models/correspondence.rb
+++ b/app/models/correspondence.rb
@@ -3,7 +3,9 @@ class Correspondence
   include ActiveModel::Model
   include ActiveModel::Validations
 
-  validates_presence_of :name, :email, :type, :message, :topic
+  validates_presence_of :name, :email, :email_confirmation, :type, :message, :topic
+
+  validates :email, confirmation: { case_sensitive: false }
 
   validates_format_of :email, with: /@/
 

--- a/app/views/correspondence/new.html.slim
+++ b/app/views/correspondence/new.html.slim
@@ -13,4 +13,6 @@
 
 	= f.email_field :email
 
+	= f.email_field :email_confirmation
+
 	= f.submit 'Send', {class:'button', onclick: "ga('send', 'event', 'Question', 'Sent')"}

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -34,6 +34,7 @@ en:
     label:
       correspondence:
         name: Full name
+        email_confirmation: Confirm email
     hint:
       correspondence:
         email: |

--- a/spec/controllers/correspondence_controller_spec.rb
+++ b/spec/controllers/correspondence_controller_spec.rb
@@ -11,9 +11,10 @@ RSpec.describe CorrespondenceController, type: :controller do
   let(:params) do
     {
       correspondence: {
-        name:     external_user.name,
-        email:    external_user.email,
-        topic:    "prisons_and_probation",
+        name:               external_user.name,
+        email:              external_user.email,
+        email_confirmation: external_user.email,
+        topic:              "prisons_and_probation",
         message:  'Question about prisons and probation from member of public'
       }
     }

--- a/spec/factories/correspondence.rb
+++ b/spec/factories/correspondence.rb
@@ -2,6 +2,7 @@ FactoryGirl.define do
   factory :correspondence do
     name { Faker::Name.name }
     email { Faker::Internet.email }
+    email_confirmation { email }
     type 'general_enquiries'
     topic 'prisons_and_probation'
     message { Faker::Lorem.paragraph(1) }

--- a/spec/features/send_correspondence_spec.rb
+++ b/spec/features/send_correspondence_spec.rb
@@ -10,15 +10,17 @@ feature 'Submit a general enquiry' do
         "Topic can't be blank",
         "Full name can't be blank",
         "Email can't be blank",
+        "Confirm email can't be blank",
         "Message can't be blank"
       ]
     end
 
   scenario 'Using valid inputs' do
     visit 'correspondence/new'
-    fill_in 'correspondence[name]',     with: name
-    fill_in 'correspondence[email]',    with: email
-    fill_in 'correspondence[message]',  with: message
+    fill_in 'correspondence[name]',               with: name
+    fill_in 'correspondence[email]',              with: email
+    fill_in 'correspondence[message]',            with: message
+    fill_in 'correspondence[email_confirmation]', with: email
     choose 'Prisons and probation'
     click_button 'Send'
     expect(page).to have_content('Your message has been sent')
@@ -26,12 +28,23 @@ feature 'Submit a general enquiry' do
     expect(page.current_path).to eq root_path
   end
 
-  scenario 'Without supplying a topic, name, email address or message' do
+  scenario 'Without a topic, name, email address, confirm email or message' do
     visit 'correspondence/new'
     click_button 'Send'
     error_messages.each do
       |error_message| expect(page).to have_content(error_message)
     end
+  end
+
+  scenario 'With mismatching email and confirm email inputs' do
+    visit 'correspondence/new'
+    fill_in 'correspondence[name]',               with: name
+    fill_in 'correspondence[email]',              with: email
+    fill_in 'correspondence[message]',            with: message
+    fill_in 'correspondence[email_confirmation]', with: 'mismatch@email.com'
+    choose 'Prisons and probation'
+    click_button 'Send'
+    expect(page).to have_content("Confirm email doesn't match Email")
   end
 
   scenario 'and refreshing the page, does not cause a routing error' do

--- a/spec/models/correspondence_spec.rb
+++ b/spec/models/correspondence_spec.rb
@@ -23,6 +23,7 @@ RSpec.describe Correspondence, type: :model do
     it { should validate_presence_of :type }
     it { should validate_presence_of :topic }
     it { should validate_presence_of :message }
+    it { should validate_confirmation_of :email}
   
     it do
       should validate_inclusion_of(:topic).


### PR DESCRIPTION
https://trello.com/c/AKVmTzV3/252-add-the-confirmation-email-field-back-into-the-ask-tool-form-and-make-sure-the-label-reads-confirm-email-1

- Required until we have a page that confirms all inputs prior to submission