### PR TITLE
248 Replace 'Development' with 'ALPHA on the phase banner'

### DIFF
--- a/app/assets/stylesheets/moj/_govuk_overrides.scss
+++ b/app/assets/stylesheets/moj/_govuk_overrides.scss
@@ -17,10 +17,6 @@
   }
 }
 
-.phase-banner {
-  @include phase-banner(beta);
-}
-
 #proposition-name{
   float: left;
 }

--- a/app/views/layouts/_phase_banner.html.slim
+++ b/app/views/layouts/_phase_banner.html.slim
@@ -1,7 +1,7 @@
-.phase-banner
+.phase-banner-alpha
   p
     strong.phase-tag
-      = "DEVELOPMENT"
+      = "ALPHA"
     span
       | This is a new service – your feedback will help us to improve it.
 


### PR DESCRIPTION
The phase banner content has been updated and styling hack was removed.
This is because we have passed alpha stage.

https://dsdmoj.atlassian.net/browse/CT-76
