### PR TITLE
CT-115 Managing customer expectations

### DIFF
--- a/app/views/correspondence/confirmation.html.slim
+++ b/app/views/correspondence/confirmation.html.slim
@@ -6,7 +6,7 @@
 h2.heading-medium
   | What happens next
 p
-  | We aim to respond to questions within 20 working days.
+  | We will respond to your question as soon as possible.
 
 .button-holder
   = link_to "Finish",root_path, {role: 'button', class: 'button-secondary'}


### PR DESCRIPTION
The business were concerned about mentioning 20 working days on the
confirmation page when it may be less or potentially more. This
would also reduce the users confidence in getting a timely reply.

https://dsdmoj.atlassian.net/browse/CT-115 
