### PR TITLE
Order of validations == order of errors on page

### DIFF
--- a/app/models/correspondence.rb
+++ b/app/models/correspondence.rb
@@ -3,18 +3,24 @@ class Correspondence
   include ActiveModel::Model
   include ActiveModel::Validations
 
-  validates_presence_of :name, :email, :email_confirmation, :type, :message, :topic
+  validates_presence_of :topic,
+                        :message,
+                        :name,
+                        :email,
+                        :email_confirmation,
+                        :type
 
   validates :email, confirmation: { case_sensitive: false }
 
-  validates_format_of :email, with: /@/
+  validates_format_of :email, with: /@/,
+    if: Proc.new { email.present? }
 
   validates_inclusion_of :type,
     in: Settings.correspondence_types,
-    if: Proc.new { |correspondence| correspondence.type.present? }
+    if: Proc.new { type.present? }
   validates_inclusion_of :topic,
     in: Settings.correspondence_topics,
-    if: Proc.new { |correspondence| correspondence.topic.present? }
+    if: Proc.new { topic.present? }
 
   attr_accessor :name, :email, :type, :topic, :message
 


### PR DESCRIPTION
https://dsdmoj.atlassian.net/browse/CT-73

- Error messages shown at the top of the form should be in the same order as the form fields appear below.
- Email format validation should only be applied if the email field is not blank