### PR TITLE
CT-130 #peer-review Add correct domain to urls

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -33,7 +33,8 @@ Rails.application.configure do
   config.active_job.queue_adapter = :sidekiq
   config.action_mailer.delivery_method = :smtp
 
-  config.action_mailer.asset_host  = 'http://localhost:3000'
+  config.action_mailer.default_url_options = { host: ENV['AAQ_EMAIL_DOMAIN'] }
+  config.action_mailer.asset_host = config.action_mailer.default_url_options[:host]
 
   # Print deprecation notices to the Rails logger.
   config.active_support.deprecation = :log

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -33,7 +33,7 @@ Rails.application.configure do
   config.active_job.queue_adapter = :sidekiq
   config.action_mailer.delivery_method = :smtp
 
-  config.action_mailer.default_url_options = { host: ENV['AAQ_EMAIL_DOMAIN'] }
+  config.action_mailer.default_url_options = { host: ENV.fetch('AAQ_EMAIL_DOMAIN') }
   config.action_mailer.asset_host = config.action_mailer.default_url_options[:host]
 
   # Print deprecation notices to the Rails logger.

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -29,7 +29,9 @@ Rails.application.configure do
 
   config.action_mailer.delivery_method = :smtp
   config.active_job.queue_adapter = :sidekiq
-  config.action_mailer.asset_host  = 'https://correspondance.herokuapp.com'
+
+  config.action_mailer.default_url_options = { host: ENV['AAQ_EMAIL_DOMAIN'] }
+  config.action_mailer.asset_host = config.action_mailer.default_url_options[:host]
 
   # Enable serving of images, stylesheets, and JavaScripts from an asset server.
   # config.action_controller.asset_host = 'http://assets.example.com'

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -30,7 +30,7 @@ Rails.application.configure do
   config.action_mailer.delivery_method = :smtp
   config.active_job.queue_adapter = :sidekiq
 
-  config.action_mailer.default_url_options = { host: ENV['AAQ_EMAIL_DOMAIN'] }
+  config.action_mailer.default_url_options = { host: ENV.fetch('AAQ_EMAIL_DOMAIN') }
   config.action_mailer.asset_host = config.action_mailer.default_url_options[:host]
 
   # Enable serving of images, stylesheets, and JavaScripts from an asset server.

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -34,7 +34,7 @@ Rails.application.configure do
   # ActionMailer::Base.deliveries array.
   config.action_mailer.delivery_method = :test
 
-  config.action_mailer.default_url_options = { host: ENV['AAQ_EMAIL_DOMAIN'] }
+  config.action_mailer.default_url_options = { host: ENV.fetch('AAQ_EMAIL_DOMAIN') }
   config.action_mailer.asset_host = config.action_mailer.default_url_options[:host]
 
   config.active_job.queue_adapter = :test

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -33,7 +33,10 @@ Rails.application.configure do
   # The :test delivery method accumulates sent emails in the
   # ActionMailer::Base.deliveries array.
   config.action_mailer.delivery_method = :test
-  
+
+  config.action_mailer.default_url_options = { host: ENV['AAQ_EMAIL_DOMAIN'] }
+  config.action_mailer.asset_host = config.action_mailer.default_url_options[:host]
+
   config.active_job.queue_adapter = :test
   # Print deprecation notices to the stderr.
   config.active_support.deprecation = :stderr


### PR DESCRIPTION
https://dsdmoj.atlassian.net/browse/CT-130

Emails were not displaying the images.

- They were pointing to the old heroku instance which was renamed
   and we looking to remove shortly.

- Added a new system environment variable to store the domain that
  will be added to the urls that the mailer produces.