### PR TITLE
Save Feedback to DB, not logfile

### DIFF
--- a/app/controllers/feedback_controller.rb
+++ b/app/controllers/feedback_controller.rb
@@ -7,9 +7,8 @@ class FeedbackController < ApplicationController
   def create
     @feedback = Feedback.new(feedback_params)
 
-    if @feedback.valid?
-      EmailFeedbackJob.perform_later(YAML.dump(@feedback))
-      log_feedback
+    if @feedback.save
+      EmailFeedbackJob.perform_later(@feedback)
       redirect_to correspondence_url, notice: 'Feedback submitted'
     else
       render :new
@@ -18,27 +17,8 @@ class FeedbackController < ApplicationController
 
   private
 
-  def log_feedback
-    Rails.configuration.feedback_logger.info(
-      {
-        feedback:
-          {
-            timestamp: DateTime.now.to_s,
-            rating: @feedback.rating.humanize,
-            comment:   @feedback.comment
-              .gsub('\\', '\\\\')
-              .gsub("\n", '\\n')
-              .gsub("\r", '\\r')
-          }
-      }.to_json
-    )
-  end
-
   def feedback_params
-    params.require(:feedback).permit(
-      :rating,
-      :comment
-      ) 
+    params.require(:feedback).permit(:rating, :comment) 
   end
 
 end

--- a/app/jobs/email_feedback_job.rb
+++ b/app/jobs/email_feedback_job.rb
@@ -4,8 +4,8 @@ class EmailFeedbackJob < ApplicationJob
 
   queue_as :mailers
 
-  def perform(feedback_yaml)
-    feedback = YAML.load(feedback_yaml)
+  def perform(feedback_id)
+    feedback = Feedback.find(feedback_id)
     FeedbackMailer.new_feedback(feedback).deliver_now
   end
 

--- a/app/models/feedback.rb
+++ b/app/models/feedback.rb
@@ -1,9 +1,4 @@
-class Feedback
-
-  include ActiveModel::Model
-  include ActiveModel::Validations
-
-  attr_accessor :rating, :comment
+class Feedback < ActiveRecord::Base
 
   validates :rating, inclusion: { in:  Settings.service_feedback,
                                   message: "please select one option"}

--- a/config/initializers/feedback_logger.rb
+++ b/config/initializers/feedback_logger.rb
@@ -1,5 +1,0 @@
-Rails.application.configure do
-  filename = Rails.env.test? ? 'test_service_feedback.log' : 'service_feedback.log'
-  Settings.feedback_log = File.join('log', filename)
-  config.feedback_logger = ActiveSupport::Logger.new(Settings.feedback_log)
-end

--- a/db/migrate/20161013090839_create_feedback.rb
+++ b/db/migrate/20161013090839_create_feedback.rb
@@ -1,0 +1,10 @@
+class CreateFeedback < ActiveRecord::Migration[5.0]
+  def change
+    create_table :feedback do |t|
+      t.string :rating
+      t.text :comment
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20161011093432) do
+ActiveRecord::Schema.define(version: 20161013090839) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -21,6 +21,13 @@ ActiveRecord::Schema.define(version: 20161011093432) do
     t.string   "category"
     t.string   "topic"
     t.text     "message"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+  create_table "feedback", force: :cascade do |t|
+    t.string   "rating"
+    t.text     "comment"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end

--- a/spec/jobs/email_feedback_job_spec.rb
+++ b/spec/jobs/email_feedback_job_spec.rb
@@ -2,17 +2,24 @@ require 'rails_helper'
 
 RSpec.describe EmailFeedbackJob, type: :job do
   
-  let(:feedback) { build(:feedback) }
+  let(:feedback) { create(:feedback) }
+  subject        { EmailFeedbackJob.new }
 
-  describe '#perform_later' do
+  before do
+    ActiveJob::Base.queue_adapter = :test
+  end
 
-    before do
-      @feedback_yaml = YAML.dump(feedback)
-      ActiveJob::Base.queue_adapter = :test
+  describe '#perform' do
+    it 'sends an email' do
+      expect { subject.perform(feedback.id) }
+        .to change { ActionMailer::Base.deliveries.count }.by 1
     end
+  end
 
-    it 'accepts a serialised object and adds a job to the queue' do
-      expect { EmailFeedbackJob.perform_later(@feedback_yaml) }.to have_enqueued_job(EmailFeedbackJob)
+  describe '.perform_later' do
+    it 'accepts the ID of a feedback and enqueues an EmailFeedbackJob' do
+      expect { EmailFeedbackJob.perform_later(feedback.id) }
+        .to have_enqueued_job(EmailFeedbackJob)
     end
   end
 

--- a/spec/models/feedback_spec.rb
+++ b/spec/models/feedback_spec.rb
@@ -2,26 +2,14 @@ require 'rails_helper'
 
 RSpec.describe Feedback, type: :model do
 
-  let(:feedback) { build :feedback }
+  subject { build :feedback }
 
-  describe 'has a factory' do
-    it 'that produces a valid object by default' do
-      expect(feedback).to be_valid
-    end
-  end
-
+    it { should be_valid }
+    it { should validate_inclusion_of(:rating).in_array Settings.service_feedback }
 
   describe 'Feedback env variable is not null' do
     it 'has a specific email address associated' do
       expect(ENV["AAQ_FEEDBACK_EMAIL"]).not_to be nil
-    end
-  end
-
-  describe 'attributes' do
-
-    it do
-      should validate_inclusion_of(:rating).
-        in_array( Settings.service_feedback)
     end
   end
 


### PR DESCRIPTION
https://dsdmoj.atlassian.net/browse/CT-161
- feedback was being saved to logfile
- this was going to be complicated to access and maintain
- save to DB instead

Next
- Implement an API to display feedback ratings on Geckoboard
- Ticket created: https://dsdmoj.atlassian.net/browse/CT-162