### PR TITLE
Clean up configs using env vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,22 @@ $ git clone git@github.com:ministryofjustice/correspondence_tool_public.git
 $ cd correspondence_tool_public
 ```
 
+### Setup MailCatcher
+
+When developing or testing locally we use
+[MailCatcher](https://mailcatcher.me/) to capture mail being sent locally and
+view it locally. The development environment is already setup to use
+MailCatcher so install it and run it:
+
+```bash
+$ gem install mailcatcher
+$ mailcatcher --smtp-port 2050
+```
+
+We run it on port 2050 because MacOS appears to be running the new
+`cloud-drive` process on default MailCatcher port (1025). Once run, you can
+visit http://localhost:1080/ to view what emails have been sent locally.
+
 ## Production Environment Setup
 
 ### Web Server Setup

--- a/README.md
+++ b/README.md
@@ -38,3 +38,32 @@ visit http://localhost:1080/ to view what emails have been sent locally.
 `public/images` contains images required by the static 500 error.
 
 `public/files` contains the stylesheet required by the static 500 error.
+
+### Environment Variables
+
+Certain settings are controlled by environment variables so that they can
+controlled by the deployment environment they are in (dev, staging, prod, etc)
+and so that secret or sensitive values aren't kept with the repository. See
+the `config/settings.yml` file for a full list, any variable there can be
+over-ridden with an environment variable with the same name but prefixed with
+`SETTINGS__`.
+
+* **SETTINGS__GA_TRACKING_ID** — the tracking ID used for Google
+  Analytics. Can be unset in which case it will be empty-string.
+* **SETTINGS__SENDGRID_USERNAME** — The username to use to login
+  to SendGrid. Note that SendGrid isn't used in local development (as
+  described above we use MailCatcher running on localhost:2050).
+* **SETTINGS__SENDGRID_PASSWORD** — The password for SendGrid. See above.
+* **SETTINGS__CORRESPONDENCE_EMAIL_FROM** — The email address
+  which will be used in the From address of email sent for correspondence and
+  feedback.
+* **SETTINGS__GENERAL_ENQUIRIES_EMAIL** — The email address to
+  send general correspondence emails to.
+* **SETTINGS__FREEDOM_OF_INFORMATION_REQUEST_EMAIL** — The email
+  address to send freedom of information request emails to. (Currently unused,
+  this should probably be removed.)
+* **SETTINGS__AAQ_FEEDBACK_EMAIL** — The email address to send
+  feedback to.
+* **SETTINGS__AAQ_EMAIL_URL** — The URL used for static assets
+  presented in the correspondence email.
+

--- a/README.md
+++ b/README.md
@@ -41,12 +41,12 @@ visit http://localhost:1080/ to view what emails have been sent locally.
 
 ### Environment Variables
 
-Certain settings are controlled by environment variables so that they can
-controlled by the deployment environment they are in (dev, staging, prod, etc)
-and so that secret or sensitive values aren't kept with the repository. See
-the `config/settings.yml` file for a full list, any variable there can be
-over-ridden with an environment variable with the same name but prefixed with
-`SETTINGS__`.
+Certain settings are defined by environment variables so that they can be
+specific to the deployment environment in which the app is running (dev,
+staging, prod, etc) and secret or sensitive values aren't kept within the
+repository. See the `config/settings.yml` file for a full list, any variable
+there can be over-ridden with an environment variable of the same name but
+prefixed with `SETTINGS__`.
 
 * **SETTINGS__GA_TRACKING_ID** — the tracking ID used for Google
   Analytics. Can be unset in which case it will be empty-string.

--- a/README.md
+++ b/README.md
@@ -4,69 +4,18 @@
 
 A simple application to allow public users to submit correspondence. A present this only forwards the request to a set email address.
 
-##Local development
+## Local development
 
-###Clone this repository change to the new directory
+### Clone this repository change to the new directory
 
 ```bash
 $ git clone git@github.com:ministryofjustice/correspondence_tool_public.git
 $ cd correspondence_tool_public
 ```
 
-### Setup Docker 
+## Production Environment Setup
 
-The reason Docker is used in while in development is to overcome issues with Ruby,Rails, Postgres version conflicts and time to set these up for new developers.
-
-Majority of the team uses Docker Toolbox. Docker for Mac is currently in beta but for the time being just use Docker Toolbox. [Download](https://www.docker.com/products/docker-toolbox) and follow the [installation instructions](https://docs.docker.com/toolbox/toolbox_install_mac/)
-
-###Build Docker Image and bring the Docker Containers up
-First build the initial docker image that will be used for the container.
-
-In the root directory of the project run the following
-
-```
-$ docker-compose build
-
-...Loads of installation output ...
-
-Successfully built -- Random image ID --
-
-$ docker-compose up
-
-...outputs the following
-Recreating correspondencetoolpublic_web_1
-Attaching to correspondencetoolpublic_web_1
-web_1  | Puma starting in single mode...
-web_1  | * Version 3.4.0 (ruby 2.3.1-p112), codename: Owl Bowl Brawl
-web_1  | * Min threads: 5, max threads: 5
-web_1  | * Environment: development
-web_1  | * Listening on tcp://0.0.0.0:3000
-web_1  | Use Ctrl-C to stop
-
-```
-
-To access the site you need to find the IP address of the docker machine.
-
-```
-$ docker-machine ip
-192.168.99.100
-$ 
-```
-So if you open your favourite web browser and go to https://192.168.99.100:3000 (obviously substitute the ip with the docker machines ip)
-
-You should be greeted with the services home page
-
-###Questions about Docker
-
-#### 1. Where should I make the changes?
-The docker containers use a symlink to your local machine so any changes you make to the project files will automatically be synced with the docker containers. However if you if you need to ```bundle install``` then its best to SSH into the docker container and run it from there. The reason for this is that it will then use the docker containers version of Ruby/Rails to install the gems.
-
-####2. Do I have to rebuild the Docker Image after I made changes to the local files?
-No, as mentioned in question 1. the rails files are sync automatically with your local machine.
-
-##Production Environment Setup
-
-###Web Server Setup
+### Web Server Setup
 
 `public/500-nginx.html` provides a static 500 error for when the Rails application cannot be reached.
 

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -1,4 +1,4 @@
 class ApplicationMailer < ActionMailer::Base
-  default from: ENV['CORRESPONDENCE_EMAIL_FROM']
+  default from: Settings.correspondence_email_from
   layout 'mailer'
 end

--- a/app/mailers/correspondence_mailer.rb
+++ b/app/mailers/correspondence_mailer.rb
@@ -2,7 +2,7 @@ class CorrespondenceMailer < ApplicationMailer
 
   def new_correspondence(correspondence)
     @correspondence = correspondence
-    mail to: Settings["#{@correspondence.category}_email"]
+    mail to: Settings["#{@correspondence.category}_email"],
          subject: "New #{@correspondence.category.humanize} - #{@correspondence.topic.humanize}"
   end
 

--- a/app/mailers/correspondence_mailer.rb
+++ b/app/mailers/correspondence_mailer.rb
@@ -2,7 +2,7 @@ class CorrespondenceMailer < ApplicationMailer
 
   def new_correspondence(correspondence)
     @correspondence = correspondence
-    mail to: ENV["#{@correspondence.category.upcase}_EMAIL"],
+    mail to: Settings["#{@correspondence.category}_email"]
          subject: "New #{@correspondence.category.humanize} - #{@correspondence.topic.humanize}"
   end
 

--- a/app/mailers/feedback_mailer.rb
+++ b/app/mailers/feedback_mailer.rb
@@ -2,7 +2,7 @@ class FeedbackMailer < ApplicationMailer
 
   def new_feedback(feedback)
     @feedback = feedback
-    mail to: ENV['AAQ_FEEDBACK_EMAIL'],
+    mail to: Settings.aaq_feedback_email,
          subject: "Ask Tool Feedback - #{@feedback.rating.humanize}"
   end
 

--- a/config/application.rb
+++ b/config/application.rb
@@ -19,8 +19,8 @@ Bundler.require(*Rails.groups)
 module CorrespondenceToolPublic
   class Application < Rails::Application
 
-    config.ga_tracking_id = (ENV['GA_TRACKING_ID'] || '')
-    
+    config.ga_tracking_id = Settings.ga_tracking_id
+
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration should go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded.

--- a/config/environment.rb
+++ b/config/environment.rb
@@ -6,10 +6,14 @@ Rails.configuration.action_mailer.smtp_settings = {
     :address              => "smtp.sendgrid.net",
     :port                 => 587,
     :domain               => 'digital.justice.gov.uk',
-    :user_name            => ENV['CORRESPONDENCE_EMAIL_USERNAME'],
-    :password             => ENV['CORRESPONDENCE_EMAIL_PASSWORD'],
+    :user_name            => Settings.sendgrid_username,
+    :password             => Settings.sendgrid_password,
     :authentication       => :plain,
     :enable_starttls_auto => true
+}
+
+Rails.configuration.action_mailer.default_url_options = {
+  host: Settings.aaq_email_url
 }
 
 # Initialize the Rails application.

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -28,13 +28,19 @@ Rails.application.configure do
 
   # Do care if the mailer can't send.
   config.action_mailer.raise_delivery_errors = true
-  
+
   config.action_mailer.perform_caching = false
   config.active_job.queue_adapter = :sidekiq
   config.action_mailer.delivery_method = :smtp
 
   config.action_mailer.default_url_options = { host: ENV.fetch('AAQ_EMAIL_DOMAIN') }
   config.action_mailer.asset_host = config.action_mailer.default_url_options[:host]
+
+  config.action_mailer.smtp_settings = {
+    address: 'localhost',
+    port:    2050,
+    domain:  'digital.justice.gov.uk'
+  }
 
   # Print deprecation notices to the Rails logger.
   config.active_support.deprecation = :log

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -33,7 +33,6 @@ Rails.application.configure do
   config.active_job.queue_adapter = :sidekiq
   config.action_mailer.delivery_method = :smtp
 
-  config.action_mailer.default_url_options = { host: ENV.fetch('AAQ_EMAIL_DOMAIN') }
   config.action_mailer.asset_host = config.action_mailer.default_url_options[:host]
 
   config.action_mailer.smtp_settings = {

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -30,7 +30,6 @@ Rails.application.configure do
   config.action_mailer.delivery_method = :smtp
   config.active_job.queue_adapter = :sidekiq
 
-  config.action_mailer.default_url_options = { host: ENV.fetch('AAQ_EMAIL_DOMAIN') }
   config.action_mailer.asset_host = config.action_mailer.default_url_options[:host]
 
   # Enable serving of images, stylesheets, and JavaScripts from an asset server.

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -34,7 +34,6 @@ Rails.application.configure do
   # ActionMailer::Base.deliveries array.
   config.action_mailer.delivery_method = :test
 
-  config.action_mailer.default_url_options = { host: ENV.fetch('AAQ_EMAIL_DOMAIN') }
   config.action_mailer.asset_host = config.action_mailer.default_url_options[:host]
 
   config.active_job.queue_adapter = :test

--- a/config/initializers/config.rb
+++ b/config/initializers/config.rb
@@ -8,23 +8,23 @@ Config.setup do |config|
 
   # Load environment variables from the `ENV` object and override any settings defined in files.
   #
-  # config.use_env = false
+  config.use_env = true
 
   # Define ENV variable prefix deciding which variables to load into config.
   #
-  # config.env_prefix = 'Settings'
+  config.env_prefix = 'SETTINGS'
 
   # What string to use as level separator for settings loaded from ENV variables. Default value of '.' works well
   # with Heroku, but you might want to change it for example for '__' to easy override settings from command line, where
   # using dots in variable names might not be allowed (eg. Bash).
   #
-  # config.env_separator = '.'
+  config.env_separator = '__'
 
   # Ability to process variables names:
   #   * nil  - no change
   #   * :downcase - convert to lower case
   #
-  # config.env_converter = nil
+  # config.env_converter = :downcase
 
   # Parse numeric values as integers instead of strings.
   #

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -15,5 +15,13 @@ service_feedback:
   - dissatisfied
   - very_dissatisfied
 
+ga_tracking_id: ''
+
+sendgrid_username: sendgrid
+sendgrid_password: password
+
+correspondence_email_from: correspondence_tool@localhost
 general_enquiries_email: general_enquiries@localhost
 freedom_of_information_request_email: foi_request@localhost
+aaq_feedback_email: feedback@localhost
+aaq_email_url: http://localhost/

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -15,6 +15,8 @@ service_feedback:
   - dissatisfied
   - very_dissatisfied
 
+# Variables below are meant to be over-ridden in non-local environments (dev,
+# staging, prod) with correct values. The values below are place-holders.
 ga_tracking_id: ''
 
 sendgrid_username: sendgrid

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -14,3 +14,6 @@ service_feedback:
   - neither_satisfied_nor_dissatisfied
   - dissatisfied
   - very_dissatisfied
+
+general_enquiries_email: general_enquiries@localhost
+freedom_of_information_request_email: foi_request@localhost

--- a/spec/jobs/email_correspondence_job_spec.rb
+++ b/spec/jobs/email_correspondence_job_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe EmailCorrespondenceJob, type: :job do
-  
+
   let(:correspondence) { create(:correspondence) }
   subject              { EmailCorrespondenceJob.new }
 

--- a/spec/mailers/correspondence_mailer_spec.rb
+++ b/spec/mailers/correspondence_mailer_spec.rb
@@ -26,12 +26,12 @@ RSpec.describe CorrespondenceMailer, type: :mailer do
 
     context 'to the correct address for' do
       it 'freedom of information requests' do
-        expect(@mail.to).to eq [ ENV['FREEDOM_OF_INFORMATION_REQUEST_EMAIL'] ]
+        expect(@mail.to).to eq ['foi_request@localhost']
       end
 
       it 'general_enquiries' do
         send_email('general_enquiries')
-        expect(@mail.to).to eq [ ENV['GENERAL_ENQUIRIES_EMAIL'] ]
+        expect(@mail.to).to eq ['general_enquiries@localhost']
       end
 
     end

--- a/spec/mailers/feedback_mailer_spec.rb
+++ b/spec/mailers/feedback_mailer_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe FeedbackMailer, type: :mailer do
     end
 
     it 'should send to the correct address' do
-      expect(@mail.to).to eq [ ENV['AAQ_FEEDBACK_EMAIL'] ]
+      expect(@mail.to).to eq [ 'feedback@localhost' ]
     end
 
     it 'should have a subject that contains the rating' do

--- a/spec/models/correspondence_spec.rb
+++ b/spec/models/correspondence_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Correspondence, type: :model do
   describe 'each category' do
     Settings.correspondence_categories.each do |category|
       it 'has a specific email address associated' do
-        expect(ENV["#{category.upcase}_EMAIL"]).not_to be nil
+        expect(Settings["#{category}_email"]).not_to be nil
       end
     end
   end
@@ -22,7 +22,7 @@ RSpec.describe Correspondence, type: :model do
     it { should validate_presence_of      :topic }
     it { should validate_presence_of      :message }
     it { should validate_confirmation_of  :email}
-  
+
     it do
       should validate_inclusion_of(:topic).
         in_array(Settings.correspondence_topics)

--- a/spec/models/feedback_spec.rb
+++ b/spec/models/feedback_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Feedback, type: :model do
 
   describe 'Feedback env variable is not null' do
     it 'has a specific email address associated' do
-      expect(ENV["AAQ_FEEDBACK_EMAIL"]).not_to be nil
+      expect(Settings.aaq_feedback_email).not_to be nil
     end
   end
 


### PR DESCRIPTION
Move env vars into `settings.yml` so that they aren't required to run the app. Instead, we have acceptable defaults for development in `settings.yml` and can override them with env vars (e.g. SETTINGS__GENERAL_ENQUIRIES_EMAIL) in the deployment environments.

This PR will require a matching change to ministryofjustice/correspondence-tool-deploy which has yet to be done.