### PR TITLE
Make correspondence consistent with Feedback

### DIFF
--- a/app/controllers/correspondence_controller.rb
+++ b/app/controllers/correspondence_controller.rb
@@ -12,7 +12,7 @@ class CorrespondenceController < ApplicationController
     @correspondence = Correspondence.new(general_enquiry_attributes)
 
     if @correspondence.save
-      EmailCorrespondenceJob.perform_later(YAML.dump(@correspondence))
+      EmailCorrespondenceJob.perform_later(@correspondence)
       render 'correspondence/confirmation'
     else
       render :new
@@ -22,9 +22,7 @@ class CorrespondenceController < ApplicationController
   private
 
   def general_enquiry_attributes
-    correspondence_params.merge(
-      category: 'general_enquiries'
-    )
+    correspondence_params.merge(category: 'general_enquiries')
   end
 
   def correspondence_params

--- a/app/jobs/email_correspondence_job.rb
+++ b/app/jobs/email_correspondence_job.rb
@@ -2,9 +2,8 @@ class EmailCorrespondenceJob < ApplicationJob
 
   queue_as :mailers
 
-  def perform(correspondence_yaml)
-    correspondence = YAML.load(correspondence_yaml)
+  def perform(correspondence_id)
+    correspondence = Correspondence.find(correspondence_id)
     CorrespondenceMailer.new_correspondence(correspondence).deliver_now
   end
-
 end

--- a/spec/jobs/email_correspondence_job_spec.rb
+++ b/spec/jobs/email_correspondence_job_spec.rb
@@ -2,17 +2,22 @@ require 'rails_helper'
 
 RSpec.describe EmailCorrespondenceJob, type: :job do
   
-  let(:correspondence) { build(:correspondence) }
+  let(:correspondence) { create(:correspondence) }
+  subject              { EmailCorrespondenceJob.new }
 
-  describe '#perform_later' do
+  describe '#perform' do
 
-    before do
-      @correspondence_yaml = YAML.dump(correspondence)
-      ActiveJob::Base.queue_adapter = :test
+    it 'sends an email' do
+      expect { subject.perform(correspondence.id) }
+        .to change { ActionMailer::Base.deliveries.count }.by 1
     end
+  end
 
-    it 'accepts a serialised object and adds a job to the queue' do
-      expect { EmailCorrespondenceJob.perform_later(@correspondence_yaml) }.to have_enqueued_job(EmailCorrespondenceJob)
+  describe '.perform_later' do
+
+    it 'accepts the ID of a correspondence and enqueues a job' do
+      expect { EmailCorrespondenceJob.perform_later(correspondence) }
+        .to have_enqueued_job(EmailCorrespondenceJob)
     end
   end
 

--- a/spec/models/correspondence_spec.rb
+++ b/spec/models/correspondence_spec.rb
@@ -4,9 +4,7 @@ RSpec.describe Correspondence, type: :model do
 
   subject { build :correspondence }
 
-  describe 'test object instantiated by FactoryGirl' do
-    it { should be_valid }
-  end
+  it { should be_valid }
 
   describe 'each category' do
     Settings.correspondence_categories.each do |category|
@@ -16,7 +14,7 @@ RSpec.describe Correspondence, type: :model do
     end
   end
 
-  describe 'attributes' do
+  describe 'validations' do
 
     it { should validate_presence_of      :name }
     it { should validate_presence_of      :email }


### PR DESCRIPTION
- Following refactor of FeedbackJob and FeedbackController
- Made equivalent changes here to be consistent
- Save to DB before calling EmailCorrespondenceJob
- Retrieve from DB inside Job
- Increase test coverage of Job and Controller

- I am not sure whether to go with EmailCorrespondenceJob or CorrespondenceJob (we should use the same approach for both Feedback and Correspondence though).
- I will implement the necessary changes once we've agreed on a strategy, before this gets merged.