### PR TITLE
CT-168 always log to stdout in production

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -80,11 +80,9 @@ Rails.application.configure do
   # require 'syslog/logger'
   # config.logger = ActiveSupport::TaggedLogging.new(Syslog::Logger.new 'app-name')
 
-  if ENV["RAILS_LOG_TO_STDOUT"].present?
-    logger           = ActiveSupport::Logger.new(STDOUT)
-    logger.formatter = config.log_formatter
-    config.logger = ActiveSupport::TaggedLogging.new(logger)
-  end
+  logger           = ActiveSupport::Logger.new(STDOUT)
+  logger.formatter = config.log_formatter
+  config.logger    = ActiveSupport::TaggedLogging.new(logger)
 
   # Do not dump schema after migrations.
   #config.active_record.dump_schema_after_migration = false

--- a/run.sh
+++ b/run.sh
@@ -11,5 +11,4 @@ migrate)
     bundle exec rails db:migrate
     ;;
 esac
-bundle exec puma -d -C config/puma.rb
-tail -f /var/log/dmesg
+bundle exec puma -C config/puma.rb


### PR DESCRIPTION
This fixes the lack of application logs in the production environments by ensuring logging goes to STDOUT. It has been tested in dev by building and deploying this branch in Jenkins.