### PR TITLE
CT-153 save all feedback to db

### DIFF
--- a/app/controllers/feedback_controller.rb
+++ b/app/controllers/feedback_controller.rb
@@ -1,5 +1,4 @@
 class FeedbackController < ApplicationController
-
   def new
     @feedback = Feedback.new
   end
@@ -7,9 +6,8 @@ class FeedbackController < ApplicationController
   def create
     @feedback = Feedback.new(feedback_params)
 
-    if @feedback.valid?
+    if @feedback.save
       EmailFeedbackJob.perform_later(YAML.dump(@feedback))
-      log_feedback
       redirect_to correspondence_url, notice: 'Feedback submitted'
     else
       render :new
@@ -18,27 +16,11 @@ class FeedbackController < ApplicationController
 
   private
 
-  def log_feedback
-    Rails.configuration.feedback_logger.info(
-      {
-        feedback:
-          {
-            timestamp: DateTime.now.to_s,
-            rating: @feedback.rating.humanize,
-            comment:   @feedback.comment
-              .gsub('\\', '\\\\')
-              .gsub("\n", '\\n')
-              .gsub("\r", '\\r')
-          }
-      }.to_json
-    )
-  end
-
   def feedback_params
     params.require(:feedback).permit(
       :rating,
       :comment
-      ) 
+    )
   end
 
 end

--- a/app/controllers/feedback_controller.rb
+++ b/app/controllers/feedback_controller.rb
@@ -7,7 +7,7 @@ class FeedbackController < ApplicationController
     @feedback = Feedback.new(feedback_params)
 
     if @feedback.save
-      EmailFeedbackJob.perform_later(YAML.dump(@feedback))
+      EmailFeedbackJob.perform_later(@feedback)
       redirect_to correspondence_url, notice: 'Feedback submitted'
     else
       render :new
@@ -22,5 +22,4 @@ class FeedbackController < ApplicationController
       :comment
     )
   end
-
 end

--- a/app/jobs/email_feedback_job.rb
+++ b/app/jobs/email_feedback_job.rb
@@ -1,12 +1,10 @@
 require 'feedback'
 
 class EmailFeedbackJob < ApplicationJob
-
   queue_as :mailers
 
   def perform(feedback_yaml)
     feedback = YAML.load(feedback_yaml)
     FeedbackMailer.new_feedback(feedback).deliver_now
   end
-
 end

--- a/app/jobs/email_feedback_job.rb
+++ b/app/jobs/email_feedback_job.rb
@@ -3,8 +3,8 @@ require 'feedback'
 class EmailFeedbackJob < ApplicationJob
   queue_as :mailers
 
-  def perform(feedback_yaml)
-    feedback = YAML.load(feedback_yaml)
+  def perform(feedback_id)
+    feedback = Feedback.find(feedback_id)
     FeedbackMailer.new_feedback(feedback).deliver_now
   end
 end

--- a/app/models/feedback.rb
+++ b/app/models/feedback.rb
@@ -1,11 +1,10 @@
-class Feedback
+class Feedback < ActiveRecord::Base
+  validates :rating, inclusion: {
+              in:      Settings.service_feedback,
+              message: 'please select one option'
+            }
 
-  include ActiveModel::Model
-  include ActiveModel::Validations
-
-  attr_accessor :rating, :comment
-
-  validates :rating, inclusion: { in:  Settings.service_feedback,
-                                  message: "please select one option"}
-
+  jsonb_accessor :content,
+    rating: :string,
+    comment: :text
 end

--- a/config/initializers/feedback_logger.rb
+++ b/config/initializers/feedback_logger.rb
@@ -1,5 +1,0 @@
-Rails.application.configure do
-  filename = Rails.env.test? ? 'test_service_feedback.log' : 'service_feedback.log'
-  Settings.feedback_log = File.join('log', filename)
-  config.feedback_logger = ActiveSupport::Logger.new(Settings.feedback_log)
-end

--- a/db/migrate/20161027142803_create_feedback.rb
+++ b/db/migrate/20161027142803_create_feedback.rb
@@ -1,0 +1,9 @@
+class CreateFeedback < ActiveRecord::Migration[5.0]
+  def change
+    create_table :feedback do |t|
+      t.jsonb :content
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,12 +10,18 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20161011093432) do
+ActiveRecord::Schema.define(version: 20161027142803) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
   create_table "correspondence", force: :cascade do |t|
+    t.jsonb    "content"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+  create_table "feedback", force: :cascade do |t|
     t.jsonb    "content"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false

--- a/spec/controllers/feedback_controller_spec.rb
+++ b/spec/controllers/feedback_controller_spec.rb
@@ -7,8 +7,8 @@ RSpec.describe FeedbackController, type: :controller do
   let(:params) do
     {
       feedback: {
-        rating:              feedback.rating,
-        comment:             feedback.comment
+        rating:  feedback.rating,
+        comment: feedback.comment
       }
     }
   end
@@ -21,44 +21,46 @@ RSpec.describe FeedbackController, type: :controller do
 
   describe 'POST create' do
     context 'with valid params' do
-      before do
-        @timestamp = DateTime.now.to_s
-        post :create, params: params
+      it 'makes a DB entry' do
+        expect { post :create, params: params }
+          .to change { Feedback.count }.by 1
       end
 
-      it 'redirects to the home page' do
-        expect(response).to redirect_to(correspondence_path)
-      end
-      it 'sends #perform_later to the EmailFeedbackJob' do
-        expect(EmailFeedbackJob).to receive(:perform_later)
-        post :create, params: params        
-      end
-
-      it 'and a job is enqueued' do
+      it 'enqueues an EmailFeedbackJob' do
         expect { post :create, params: params }
           .to have_enqueued_job(EmailFeedbackJob)
       end
 
-      it 'and the submission is logged' do
-        log = File.readlines(Settings.feedback_log)
-        last_log_entry = JSON.parse(log.last)
-        user_input = last_log_entry["feedback"]
-
-        expect(user_input["timestamp"]).to eq @timestamp
-        expect(user_input["rating"]).to eq feedback.rating.humanize
-        expect(user_input["comment"]).to eq feedback.comment
+      it 'redirects to the webform' do
+        expect(post :create, params: params)
+          .to redirect_to(correspondence_path)
       end
     end
 
     context 'with invalid params' do
-      before do
-        invalid_params = params
-        invalid_params[:feedback].delete(:rating)
-        post :create, params: invalid_params
+      let(:params) do
+        {
+          feedback: {
+            # no rating
+            comment: feedback.comment
+          }
+        }
       end
 
-      it { should render_template(:new) }
+      it 'does not make a DB entry' do
+        expect { post :create, params: params }
+          .not_to change { Feedback.count }
+      end
 
+      it 'does not enqueue an EmailFeedbackJob' do
+        expect { post :create, params: params }
+          .not_to have_enqueued_job(EmailFeedbackJob)
+      end
+
+      it 'renders the :new template' do
+        expect(post :create, params: params)
+          .to render_template(:new)
+      end
     end
   end
 

--- a/spec/controllers/feedback_controller_spec.rb
+++ b/spec/controllers/feedback_controller_spec.rb
@@ -26,9 +26,10 @@ RSpec.describe FeedbackController, type: :controller do
           .to change { Feedback.count }.by 1
       end
 
-      it 'enqueues an EmailFeedbackJob' do
-        expect { post :create, params: params }
-          .to have_enqueued_job(EmailFeedbackJob)
+      it 'enqueues an EmailFeedbackJob with our feedback' do
+        post :create, params: params
+        feedback = Feedback.last
+        expect(EmailFeedbackJob).to have_been_enqueued.with(feedback)
       end
 
       it 'redirects to the webform' do

--- a/spec/jobs/email_feedback_job_spec.rb
+++ b/spec/jobs/email_feedback_job_spec.rb
@@ -1,18 +1,24 @@
 require 'rails_helper'
 
 RSpec.describe EmailFeedbackJob, type: :job do
-  
-  let(:feedback) { build(:feedback) }
+  let(:feedback) { create(:feedback) }
+  subject        { EmailFeedbackJob.new }
 
-  describe '#perform_later' do
+  before do
+    ActiveJob::Base.queue_adapter = :test
+  end
 
-    before do
-      @feedback_yaml = YAML.dump(feedback)
-      ActiveJob::Base.queue_adapter = :test
+  describe '#perform' do
+    it 'sends an email' do
+      expect { subject.perform(feedback.id) }
+        .to change { ActionMailer::Base.deliveries.count }.by 1
     end
+  end
 
-    it 'accepts a serialised object and adds a job to the queue' do
-      expect { EmailFeedbackJob.perform_later(@feedback_yaml) }.to have_enqueued_job(EmailFeedbackJob)
+  describe '.perform_later' do
+    it 'adds a job to our queue' do
+      expect { EmailFeedbackJob.perform_later(feedback) }
+        .to have_enqueued_job(EmailFeedbackJob)
     end
   end
 

--- a/spec/jobs/email_feedback_job_spec.rb
+++ b/spec/jobs/email_feedback_job_spec.rb
@@ -4,8 +4,11 @@ RSpec.describe EmailFeedbackJob, type: :job do
   let(:feedback) { create(:feedback) }
   subject        { EmailFeedbackJob.new }
 
-  before do
-    ActiveJob::Base.queue_adapter = :test
+  describe '.perform_later' do
+    it 'adds a job to our queue' do
+      expect { EmailFeedbackJob.perform_later(feedback) }
+        .to have_enqueued_job.on_queue('mailers')
+    end
   end
 
   describe '#perform' do
@@ -14,12 +17,4 @@ RSpec.describe EmailFeedbackJob, type: :job do
         .to change { ActionMailer::Base.deliveries.count }.by 1
     end
   end
-
-  describe '.perform_later' do
-    it 'adds a job to our queue' do
-      expect { EmailFeedbackJob.perform_later(feedback) }
-        .to have_enqueued_job(EmailFeedbackJob)
-    end
-  end
-
 end

--- a/spec/models/feedback_spec.rb
+++ b/spec/models/feedback_spec.rb
@@ -1,28 +1,16 @@
 require 'rails_helper'
 
 RSpec.describe Feedback, type: :model do
+  subject { build :feedback }
 
-  let(:feedback) { build :feedback }
-
-  describe 'has a factory' do
-    it 'that produces a valid object by default' do
-      expect(feedback).to be_valid
-    end
+  it { should be_valid }
+  it do
+    should validate_inclusion_of(:rating).in_array Settings.service_feedback
   end
-
 
   describe 'Feedback env variable is not null' do
     it 'has a specific email address associated' do
       expect(Settings.aaq_feedback_email).not_to be nil
     end
   end
-
-  describe 'attributes' do
-
-    it do
-      should validate_inclusion_of(:rating).
-        in_array( Settings.service_feedback)
-    end
-  end
-
 end


### PR DESCRIPTION
This PR builds ontop of #86, which should be merged first before this one.

This change reworks the original work done to get the feedback into the DB to take advantage of JSON-fields for feedback responses so that we can be flexible and change what feedback we ask for without changing the DB schema.