### PR TITLE
CT-188  Clarify successful transactions

### DIFF
--- a/app/controllers/feedback_controller.rb
+++ b/app/controllers/feedback_controller.rb
@@ -8,7 +8,7 @@ class FeedbackController < ApplicationController
 
     if @feedback.save
       EmailFeedbackJob.perform_later(@feedback)
-      redirect_to correspondence_url, notice: 'Feedback submitted'
+      render 'feedback/confirmation'
     else
       render :new
     end

--- a/app/views/feedback/confirmation.html.slim
+++ b/app/views/feedback/confirmation.html.slim
@@ -1,0 +1,7 @@
+.govuk-box-highlight
+  h1.page-title.bold-large
+    object type='image/svg+xml' data=image_path('icons/tick-white.svg') class="confirmation-tick"
+    = t('.success')
+
+.button-holder
+  = link_to t('.moj_home'),'https://www.gov.uk/government/organisations/ministry-of-justice'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -72,3 +72,6 @@ en:
       data_warning: |
         Please don't include any personal or financial information,
         for example your National Insurance or credit card numbers.
+    confirmation:
+      success: Your feedback has been sent
+      moj_home: Return to the Ministry of Justice homepage

--- a/spec/controllers/feedback_controller_spec.rb
+++ b/spec/controllers/feedback_controller_spec.rb
@@ -32,9 +32,9 @@ RSpec.describe FeedbackController, type: :controller do
         expect(EmailFeedbackJob).to have_been_enqueued.with(feedback)
       end
 
-      it 'redirects to the webform' do
+      it 'renders the confirmation template' do
         expect(post :create, params: params)
-          .to redirect_to(correspondence_path)
+          .to render_template(:confirmation)
       end
     end
 

--- a/spec/features/send_feedback_spec.rb
+++ b/spec/features/send_feedback_spec.rb
@@ -10,8 +10,8 @@ feature 'Submit service feedback' do
     choose rating
     fill_in 'feedback[comment]', with: comment
     click_button 'Send'
-    expect(current_path).to eq correspondence_path
-    expect(page).to have_content('Feedback submitted')
+    expect(current_path).to eq '/feedback'
+    expect(page).to have_content('Your feedback has been sent')
   end
 
   scenario 'Without a rating' do


### PR DESCRIPTION
Two for the price of one:
https://dsdmoj.atlassian.net/browse/CT-188
and...
https://dsdmoj.atlassian.net/browse/CT-166

Confirm that feedback has been submitted and take the user back to the MoJ homepage upon completion, rather than back to the webform, which confuses some people (they think that they need to do it all again).