### PR TITLE
Fix byebug error

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -46,6 +46,7 @@ group :development, :test do
   gem 'factory_girl_rails'
   gem 'pry'
   gem 'pry-byebug'
+  gem 'rb-readline'
   gem 'rspec-rails', '~> 3.4'
   gem 'rubocop', require: false
   gem 'rubocop-rspec', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -258,6 +258,7 @@ GEM
     rb-fsevent (0.9.7)
     rb-inotify (0.9.7)
       ffi (>= 0.5.0)
+    rb-readline (0.5.3)
     redis (3.3.1)
     request_store (1.3.1)
     responders (2.3.0)
@@ -397,6 +398,7 @@ DEPENDENCIES
   puma (~> 3.0)
   rails (~> 5.0.0)
   rails-controller-testing
+  rb-readline
   responders (~> 2.3)
   rspec-rails (~> 3.4)
   rubocop


### PR DESCRIPTION
Not certain why but in certain circumstances ruby seems to lose it's
link to the readline dylib causing byebug to raise errors when being
required, possibly as a result of a 'brew update'. The fix in this
commit is mentioned here:

https://github.com/deivid-rodriguez/byebug/issues/289

The alternative seems to be to recompile ruby.