### PR TITLE
CT-266 replace topic with text field

### DIFF
--- a/app/models/correspondence.rb
+++ b/app/models/correspondence.rb
@@ -1,4 +1,5 @@
 class Correspondence < ActiveRecord::Base
+# i18n-tasks-use t('activerecord.errors.models.correspondence.attributes.topic.blank')
 
   validates_presence_of :name,
                         :email,
@@ -15,9 +16,8 @@ class Correspondence < ActiveRecord::Base
   validates_inclusion_of :category,
     in: Settings.correspondence_categories,
     if: Proc.new { category.present? }
-  validates_inclusion_of :topic,
-    in: Settings.correspondence_topics,
-    if: Proc.new { topic.present? }
+  validates :topic,
+    length: { maximum: Settings.correspondence_topic_max_length }
 
   jsonb_accessor :content,
     name: :string,

--- a/app/views/correspondence/new.html.slim
+++ b/app/views/correspondence/new.html.slim
@@ -5,14 +5,14 @@
 
 
 = form_for @correspondence do |f|
-    = f.radio_button_fieldset :topic, choices: Settings.correspondence_topics
-	br
+    = f.text_field :topic, {maxlength: Settings.correspondence_topic_max_length}
+
     = f.text_area :message, {rows: 10}
 
-	= f.text_field :name
+    = f.text_field :name
 
-	= f.email_field :email
+    = f.email_field :email
 
-	= f.email_field :email_confirmation
+    = f.email_field :email_confirmation
 
-	= f.submit t('button.send'), {class:'button', onclick: "ga('send', 'event', 'Question', 'Sent')"}
+    = f.submit t('button.send'), {class:'button', onclick: "ga('send', 'event', 'Question', 'Sent')"}

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -29,6 +29,10 @@ en:
               inclusion: please select one option
             completeness:
               inclusion: please select one option
+        correspondence:
+          attributes:
+            topic:
+              blank: Please tell us what your query is about.
     attributes:
       feedback:
         ease_of_use: This online service was easy to use
@@ -43,8 +47,6 @@ en:
 
   helpers:
     fieldset:
-      correspondence:
-        topic: What would you like to contact us about?
       feedback:
         ease_of_use: |
           This online service was easy to use
@@ -54,6 +56,8 @@ en:
       correspondence:
         name: Full name
         email_confirmation: Confirm email
+        topic: |
+          What is your query about?
         message: |
           What do you want to tell the Ministry of Justice?
       feedback:

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -3,18 +3,14 @@ correspondence_categories:
   - freedom_of_information_request
   - smoke_test
 
-correspondence_topics:
-  - courts_and_tribunals
-  - prisons_and_probation
-  - legal_aid
-  - something_else
-
 feedback_options:
   - strongly_agree
   - agree
   - neither_agree_nor_disagree
   - disagree
   - strongly_disagree
+
+correspondence_topic_max_length: 60
 
 # Variables below are meant to be over-ridden in non-local environments (dev,
 # staging, prod) with correct values. The values below are place-holders.

--- a/spec/controllers/correspondence_controller_spec.rb
+++ b/spec/controllers/correspondence_controller_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe CorrespondenceController, type: :controller do
       name:               external_user.name,
       email:              external_user.email,
       email_confirmation: external_user.email,
-      topic:              'prisons_and_probation',
+      topic:              'prisons and probations',
       message:            'Question about prisons and probation'
     }
   end
@@ -73,7 +73,7 @@ RSpec.describe CorrespondenceController, type: :controller do
           # no name
           email:              external_user.email,
           email_confirmation: external_user.email,
-          topic:              'prisons_and_probation',
+          topic:              'prisons and probations',
           message:            'Question about prisons and probation'
         }
       end

--- a/spec/factories/correspondence.rb
+++ b/spec/factories/correspondence.rb
@@ -4,7 +4,7 @@ FactoryGirl.define do
     email { Faker::Internet.email }
     email_confirmation { email }
     category 'general_enquiries'
-    topic 'prisons_and_probation'
+    topic { Faker::Hipster.sentence 4, false, 2 }
     message { Faker::Lorem.paragraph(1) }
   end
 end

--- a/spec/features/send_correspondence_spec.rb
+++ b/spec/features/send_correspondence_spec.rb
@@ -5,9 +5,10 @@ feature 'Submit a general enquiry' do
     given(:name)            { Faker::Name.name }
     given(:email)           { Faker::Internet.email }
     given(:message)         { Faker::Lorem.paragraphs[1] }
+    given(:topic)           { Faker::Hipster.sentence }
     given(:error_messages) do
       [
-        "Topic can't be blank",
+        "What is your query about? Please tell us what your query is about.",
         "Full name can't be blank",
         "Email can't be blank",
         "Confirm email can't be blank",
@@ -28,7 +29,7 @@ feature 'Submit a general enquiry' do
     fill_in 'correspondence[email]',              with: email
     fill_in 'correspondence[message]',            with: message
     fill_in 'correspondence[email_confirmation]', with: email
-    choose 'Prisons and probation'
+    fill_in 'correspondence[topic]',              with: topic
     click_button 'Send'
     expect(page).to have_content('Your message has been sent')
     click_link 'Finish'
@@ -49,7 +50,7 @@ feature 'Submit a general enquiry' do
     fill_in 'correspondence[email]',              with: email
     fill_in 'correspondence[message]',            with: message
     fill_in 'correspondence[email_confirmation]', with: 'mismatch@email.com'
-    choose 'Prisons and probation'
+    fill_in 'correspondence[topic]',              with: topic
     click_button 'Send'
     expect(page).to have_content("Confirm email doesn't match Email")
   end

--- a/spec/mailers/correspondence_mailer_spec.rb
+++ b/spec/mailers/correspondence_mailer_spec.rb
@@ -52,7 +52,7 @@ RSpec.describe CorrespondenceMailer, type: :mailer do
       end
 
       it 'the area of interest' do
-        expect(@mail.subject).to include(@correspondence.topic.humanize)
+        expect(@mail.subject).to include(@correspondence.topic)
       end
     end
 

--- a/spec/models/correspondence_spec.rb
+++ b/spec/models/correspondence_spec.rb
@@ -17,14 +17,14 @@ RSpec.describe Correspondence, type: :model do
     it { should validate_presence_of     :name }
     it { should validate_presence_of     :email }
     it { should validate_presence_of     :category }
-    it { should validate_presence_of     :topic }
+    it do
+      should validate_presence_of(:topic).
+               with_message(
+                 'Please tell us what your query is about.'
+               )
+    end
     it { should validate_presence_of     :message }
     it { should validate_confirmation_of :email}
-
-    it do
-      should validate_inclusion_of(:topic).
-        in_array(Settings.correspondence_topics)
-    end
 
     it do
       should validate_inclusion_of(:category).
@@ -33,5 +33,6 @@ RSpec.describe Correspondence, type: :model do
 
     it { should allow_value('foo@bar.com').for :email }
     it { should_not allow_value('foobar.com').for :email  }
+    it { should validate_length_of(:topic).is_at_most(60) }
   end
 end


### PR DESCRIPTION
Replace the category radio buttons with a free text area.

https://dsdmoj.atlassian.net/secure/RapidBoard.jspa?rapidView=25&projectKey=CT&view=detail&selectedIssue=CT-266

Allow users to enter in their own topic to see if we get more useful topics from them.