### PR TITLE
CT-163 Acknowledge submission of correspondence

### DIFF
--- a/app/assets/stylesheets/email.css
+++ b/app/assets/stylesheets/email.css
@@ -57,3 +57,7 @@ p {
 td {
     padding-left: 60px;
 }
+
+.p--double-lines, .span--double-lines {
+    line-height: 2em;
+}

--- a/app/assets/stylesheets/moj/_govuk_overrides.scss
+++ b/app/assets/stylesheets/moj/_govuk_overrides.scss
@@ -24,3 +24,7 @@
 .govuk-box-highlight {
   padding-bottom: 1.5em;
 }
+
+strong {
+  font-weight: 600;
+}

--- a/app/assets/stylesheets/moj/_typography.scss
+++ b/app/assets/stylesheets/moj/_typography.scss
@@ -45,3 +45,7 @@ address {
 .before-start li{
   margin-bottom: $gutter;
 }
+
+.p--double-lines {
+  line-height: 2em;
+}

--- a/app/controllers/correspondence_controller.rb
+++ b/app/controllers/correspondence_controller.rb
@@ -15,6 +15,7 @@ class CorrespondenceController < ApplicationController
 
     if @correspondence.save
       EmailCorrespondenceJob.perform_later(@correspondence)
+      EmailConfirmationJob.perform_later(@correspondence)
       render 'correspondence/confirmation'
     else
       render :new

--- a/app/jobs/email_confirmation_job.rb
+++ b/app/jobs/email_confirmation_job.rb
@@ -1,0 +1,10 @@
+require 'correspondence'
+
+class EmailConfirmationJob < ApplicationJob
+  queue_as :mailers
+
+  def perform(correspondence_id)
+    correspondence = Correspondence.find(correspondence_id)
+    ConfirmationMailer.new_confirmation(correspondence).deliver_now
+  end
+end

--- a/app/mailers/confirmation_mailer.rb
+++ b/app/mailers/confirmation_mailer.rb
@@ -1,0 +1,11 @@
+class ConfirmationMailer < ApplicationMailer
+
+  def new_confirmation(correspondence)
+    @correspondence = correspondence
+    mail to: @correspondence.email,
+      from: 'noreply@digital.justice.gov.uk',
+      subject: "We have received your enquiry"
+  end
+
+end
+

--- a/app/views/confirmation_mailer/new_confirmation.html.slim
+++ b/app/views/confirmation_mailer/new_confirmation.html.slim
@@ -1,0 +1,1 @@
+= t('.confirmation_html', full_name: @correspondence.name)

--- a/app/views/correspondence/confirmation.html.slim
+++ b/app/views/correspondence/confirmation.html.slim
@@ -14,7 +14,7 @@
 
 .grid-row
   .column-two-thirds
-    = t('.next_copy_html')
+    = t('.next_copy_html', email: @correspondence.email)
 
 .button-holder
   div

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -92,10 +92,10 @@ en:
       success: Your message has been sent
       next_title:  What happens next
       next_copy_html: |
-        We've sent a confirmation email to %{email}<br><br>
-        We will review your message.<br><br>
-        If we're able to respond, we'll do so within 1 month.<br><br>
-        We'll send any response to the above email.<br><br>
+        <p class="p--double-lines">We've sent a confirmation email to <strong>%{email}</strong>.<br>
+        We will review your message.<br>
+        If we're able to respond, we'll do so within 1 month.<br>
+        We'll send any response to the above email.</p>
       feedback_link: What did you think of this service?
       feedback_time: (takes 30 seconds)
     start:
@@ -140,9 +140,10 @@ en:
   confirmation_mailer:
     new_confirmation:
       confirmation_html: |
-        <p>To %{full_name}<br><br>
-        Thank you for contacting the Ministry of Justice.<br><br>
+        <p class="p--double-lines">To %{full_name}<br>
+        Thank you for contacting the Ministry of Justice.<br>
         Our team will be checking what you have sent us shortly.<br>
-        We aim to get back to you within 1 month, if we are able to respond to you.<br><br>
-        MOJ team<br></p>
-        Do not reply to this email.  This address is not checked by the Ministry of Justice<br>
+        We aim to get back to you within 1 month, if we are able to respond to you.<br>
+        MOJ team</p>
+        <span class="p--double-lines">
+        Do not reply to this email.  This address is not checked by the Ministry of Justice</span>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -92,11 +92,12 @@ en:
       success: Your message has been sent
       next_title:  What happens next
       next_copy_html: |
-        <p>We will review your message.</p>
-        <p>If we're able to respond, we'll do so within 1 month.</p>
+        We've sent a confirmation email to %{email}<br><br>
+        We will review your message.<br><br>
+        If we're able to respond, we'll do so within 1 month.<br><br>
+        We'll send any response to the above email.<br><br>
       feedback_link: What did you think of this service?
       feedback_time: (takes 30 seconds)
-
     start:
       page_subheading: Before you start
       court_info_title: If you want information about a court building
@@ -112,6 +113,7 @@ en:
         letters from the court.
       reply_title: If you're waiting for a reply
       reply_response: It can take up to 1 month for us to respond.
+
   feedback:
     new:
       error_summary: Please answer the statement(s) below
@@ -134,3 +136,13 @@ en:
       Feedback form - Contact the Ministry of Justice
     feedback_confirm: |
       Feedback confirmation - Contact the Ministry of Justice
+
+  confirmation_mailer:
+    new_confirmation:
+      confirmation_html: |
+        <p>To %{full_name}<br><br>
+        Thank you for contacting the Ministry of Justice.<br><br>
+        Our team will be checking what you have sent us shortly.<br>
+        We aim to get back to you within 1 month, if we are able to respond to you.<br><br>
+        MOJ team<br></p>
+        Do not reply to this email.  This address is not checked by the Ministry of Justice<br>

--- a/spec/controllers/correspondence_controller_spec.rb
+++ b/spec/controllers/correspondence_controller_spec.rb
@@ -43,6 +43,12 @@ RSpec.describe CorrespondenceController, type: :controller do
           .to have_been_enqueued.with(Correspondence.last)
       end
 
+      it 'enqueues an EmailConfirmationJob' do
+        post :create, params: params
+        expect(EmailConfirmationJob)
+          .to have_been_enqueued.with(Correspondence.last)
+      end
+
       it 'renders the :confirmation template' do
         expect(post :create, params: params).to render_template(:confirmation)
       end
@@ -86,6 +92,11 @@ RSpec.describe CorrespondenceController, type: :controller do
       it 'does not enqueue an EmailCorrespondenceJob' do
         expect { post :create, params: params }
           .not_to have_enqueued_job(EmailCorrespondenceJob)
+      end
+
+      it 'does not enqueue an EmailConfirmationJob' do
+        expect { post :create, params: params }
+          .not_to have_enqueued_job(EmailConfirmationJob)
       end
 
       it 'renders the :new template' do

--- a/spec/factories/correspondence.rb
+++ b/spec/factories/correspondence.rb
@@ -4,7 +4,7 @@ FactoryGirl.define do
     email { Faker::Internet.email }
     email_confirmation { email }
     category 'general_enquiries'
-    topic { Faker::Hipster.sentence 4, false, 2 }
+    topic { (Faker::Hipster.sentence 4, false, 2)[0..59] }
     message { Faker::Lorem.paragraph(1) }
   end
 end

--- a/spec/features/send_correspondence_spec.rb
+++ b/spec/features/send_correspondence_spec.rb
@@ -5,7 +5,7 @@ feature 'Submit a general enquiry' do
   given(:name)            { Faker::Name.name                   }
   given(:email)           { Faker::Internet.email              }
   given(:message)         { Faker::Lorem.paragraphs[1]         }
-  given(:topic_input)     { Faker::Hipster.sentence(word_count=20)  } # rubocop:disable UselessAssignment
+  given(:topic_input)     { Faker::Hipster.sentence(word_count=20) } # rubocop:disable UselessAssignment
   given(:topic_stored)    { topic_input[0..59]                 }
   given(:error_messages) do
     [
@@ -58,8 +58,10 @@ feature 'Submit a general enquiry' do
     expect(EmailCorrespondenceJob).to have_been_enqueued.with(Correspondence.last)
     expect(EmailConfirmationJob).to have_been_enqueued.with(Correspondence.last)
 
-    click_link 'Return to the Ministry of Justice homepage'
-    expect(page.current_path).to eq root_path
+    expect(page).to have_link(
+      'Return to the Ministry of Justice homepage',
+      href: 'https://www.gov.uk/government/organisations/ministry-of-justice'
+    )
   end
 
   scenario 'Without a topic, name, email address, confirm email or message' do

--- a/spec/features/send_correspondence_spec.rb
+++ b/spec/features/send_correspondence_spec.rb
@@ -5,7 +5,7 @@ feature 'Submit a general enquiry' do
   given(:name)            { Faker::Name.name                   }
   given(:email)           { Faker::Internet.email              }
   given(:message)         { Faker::Lorem.paragraphs[1]         }
-  given(:topic_input)     { Faker::Hipster.sentence(word_count=20) } # rubocop:disable UselessAssignment
+  given(:topic_input)     { Faker::Hipster.sentence(word_count=20)  } # rubocop:disable UselessAssignment
   given(:topic_stored)    { topic_input[0..59]                 }
   given(:error_messages) do
     [
@@ -40,7 +40,7 @@ feature 'Submit a general enquiry' do
     fill_in 'correspondence[email]',              with: email
     fill_in 'correspondence[message]',            with: message
     fill_in 'correspondence[email_confirmation]', with: email
-    fill_in 'correspondence[topic]',              with: topic
+    fill_in 'correspondence[topic]',              with: topic_input
     click_button 'Send'
 
     success_messages.each do
@@ -52,7 +52,7 @@ feature 'Submit a general enquiry' do
       name: name,
       email: email,
       message: message,
-      topic: topic
+      topic: topic_stored
     )
 
     expect(EmailCorrespondenceJob).to have_been_enqueued.with(Correspondence.last)
@@ -76,7 +76,7 @@ feature 'Submit a general enquiry' do
     fill_in 'correspondence[email]',              with: email
     fill_in 'correspondence[message]',            with: message
     fill_in 'correspondence[email_confirmation]', with: 'mismatch@email.com'
-    fill_in 'correspondence[topic]',              with: topic
+    fill_in 'correspondence[topic]',              with: topic_input
     click_button 'Send'
     expect(page).to have_content("Confirm email doesn't match Email")
   end

--- a/spec/features/send_feedback_spec.rb
+++ b/spec/features/send_feedback_spec.rb
@@ -21,6 +21,11 @@ feature 'Submit service feedback' do
     expect(feedback.comment).to eq comment
     expect(feedback.ease_of_use).to eq ease_of_use
     expect(feedback.completeness).to eq completeness
+
+    expect(page).to have_link(
+      'Return to the Ministry of Justice homepage',
+      href: 'https://www.gov.uk/government/organisations/ministry-of-justice'
+    )
   end
 
   scenario 'Without a rating for ease of use or completeness' do

--- a/spec/jobs/email_confirmation_job_spec.rb
+++ b/spec/jobs/email_confirmation_job_spec.rb
@@ -1,0 +1,21 @@
+require 'rails_helper'
+
+RSpec.describe EmailConfirmationJob, type: :job do
+  let(:correspondence) { create(:correspondence) }
+  subject              { EmailConfirmationJob.new }
+
+  describe '.perform_later' do
+    it 'enqueues a job' do
+      expect { EmailConfirmationJob.perform_later(correspondence) }
+        .to have_enqueued_job.on_queue('mailers')
+    end
+  end
+
+  describe '#perform' do
+    it 'sends an email' do
+      expect { subject.perform(correspondence.id) }
+        .to change { ActionMailer::Base.deliveries.count }.by 1
+    end
+  end
+end
+

--- a/spec/mailers/confirmation_mailer_spec.rb
+++ b/spec/mailers/confirmation_mailer_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe ConfirmationMailer, type: :mailer do
     ]
   end
 
-  describe '#new_correspondence' do
+  describe '#new_confirmation' do
     let(:correspondence_category) { 'general_enquiries' }
 
     it 'sends an email' do

--- a/spec/mailers/confirmation_mailer_spec.rb
+++ b/spec/mailers/confirmation_mailer_spec.rb
@@ -1,0 +1,66 @@
+require "rails_helper"
+
+RSpec.describe ConfirmationMailer, type: :mailer do
+
+  def send_email
+    ActionMailer::Base.perform_deliveries = true
+    ActionMailer::Base.deliveries = []
+    @correspondence = build(:correspondence, category: correspondence_category)
+    ConfirmationMailer.new_confirmation(@correspondence).deliver_now
+    @mail = ActionMailer::Base.deliveries.first
+  end
+
+  before(:each) do
+    send_email
+  end
+
+  after(:each) do
+    ActionMailer::Base.deliveries.clear
+  end
+
+  let(:expected_message)  do
+    [ "To #{@correspondence.name}",
+      'Thank you for contacting the Ministry of Justice.',
+      'Our team will be checking what you have sent us shortly.',
+      'We aim to get back to you within 1 month, if we are able to respond to you',
+      'MOJ team',
+      'Do not reply to this email.',
+      'This address is not checked by the Ministry of Justice'
+    ]
+  end
+
+  describe '#new_correspondence' do
+    let(:correspondence_category) { 'general_enquiries' }
+
+    it 'sends an email' do
+      expect(ActionMailer::Base.deliveries.count).to eq 1
+    end
+
+    describe 'sender email address' do
+      subject { @mail.from }
+
+      it { is_expected.to include('noreply@digital.justice.gov.uk') }
+
+    end
+
+    describe 'destination mail address' do
+      subject { @mail.to }
+
+      it { is_expected.to include(@correspondence.email) }
+    end
+
+    describe 'and the subject' do
+      it 'confirms receipt of the message' do
+        expect(@mail.subject).to include('We have received your enquiry')
+      end
+    end
+
+    describe 'and the body' do
+      it 'contains a message from a member of the public' do
+        expected_message.each do |line|
+          expect(@mail.html_part.body.to_s).to include(line)
+        end
+      end
+    end
+  end
+end

--- a/spec/mailers/previews/confirmation_mailer_preview.rb
+++ b/spec/mailers/previews/confirmation_mailer_preview.rb
@@ -1,0 +1,7 @@
+# Preview all emails at http://localhost:3000/rails/mailers/correspondence_mailer
+class ConfirmationMailerPreview < ActionMailer::Preview
+  def new_confirmation_preview
+    @preview_correspondence = FactoryGirl.build(:correspondence)
+    ConfirmationMailer.new_confirmation(@preview_correspondence)
+  end
+end


### PR DESCRIPTION
https://dsdmoj.atlassian.net/browse/CT-163

Confirm submission of the webform, by emailing the user.

Additionally

Tests fixed:
* If you try to add more than 60 chars in a feature test, only 60 are accepted, the model validations do not kick in, but the value stored in the DB is not the same as the value we tried to input - FIXED
* In about 2.6% of test runs, the correspondence factory will generate a topic which fails length validation - FIXED

Tests / coverage added:
* MoJ homepage links on confirmation pages are present and correct
* When user attempts to input a topic of more than 60 chars, the input field won't allow it