### PR TITLE
CT-496 Add GA Tracking to the GOVUK API results

### DIFF
--- a/app/views/correspondence/search.html.slim
+++ b/app/views/correspondence/search.html.slim
@@ -20,11 +20,13 @@ p.original-message
       | The following information may help:
 
     ul.list
-      - @search_result.result_items.each do |item|
-        li = link_to item.title, item.link
+      - @search_result.result_items.each_with_index do |item, index|
+        li = link_to item.title, item.link,
+                {onclick: "ga('send', 'event', 'External Link - Results', '#{ index + 1 } - #{ item.title } - #{ item.link }')"}
 
       li.more-results
-        = link_to t('.more_results'), escape_once(@search_api_client.html_query_url)
+        = link_to t('.more_results'), escape_once(@search_api_client.html_query_url),
+                {onclick:"ga('send', 'event', 'External Link - Results', '#{ t('.more_results')}')"}
 
     = f.radio_button_fieldset :contact_requested
 

--- a/spec/features/send_correspondence_spec.rb
+++ b/spec/features/send_correspondence_spec.rb
@@ -56,6 +56,7 @@ feature 'Submit a general enquiry' do
     expect(search_page).to be_displayed
     expect(search_page.title).to eq "Contact form - Contact the Ministry of Justice\n"
     expect(search_page.self_service.size).to eq 4
+    expect(search_page.self_service_ga_events.size).to eq 4
   end
 
   scenario 'Using valid inputs', js: true do

--- a/spec/site_prism/pages/correspondence/search_page.rb
+++ b/spec/site_prism/pages/correspondence/search_page.rb
@@ -5,7 +5,7 @@ module AskTool
         set_url '/correspondence/search'
 
         elements :self_service, 'ul.list li'
-
+        elements :self_service_ga_events, 'ul.list li a[onclick]'
         element :self_serviced_radio, 'label[for="correspondence_contact_requested_no"]'
         element :self_serviced_radio_copy, '#correspondence_contact_requested_no_content'
 


### PR DESCRIPTION
https://dsdmoj.atlassian.net/browse/CT-496

This adds 4 new events It creates a category called
'External link - Results'. The first three results
are unique events by tagging their order in the results,
title and link.

The last event is generic and records how many people
clicked on the the 'More results' link