### PR TITLE
CT-605 Authenticate incoming correspondence items

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -44,6 +44,7 @@ group :test do
   gem 'shoulda-matchers', '~> 3.1'
   gem 'site_prism', '~> 2.9'
   gem 'poltergeist', '~> 1.13'
+  gem 'timecop', '~> 0.8'
 end
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -363,6 +363,7 @@ GEM
     thread (0.2.2)
     thread_safe (0.3.6)
     tilt (2.0.5)
+    timecop (0.8.1)
     tins (1.12.0)
     tzinfo (1.2.2)
       thread_safe (~> 0.1)
@@ -441,6 +442,7 @@ DEPENDENCIES
   spring-watcher-listen (~> 2.0.0)
   stopwords-filter
   susy (~> 2.2.12)
+  timecop (~> 0.8)
   tzinfo-data
   uglifier (>= 1.3.0)
   web-console

--- a/app/controllers/correspondence_controller.rb
+++ b/app/controllers/correspondence_controller.rb
@@ -21,13 +21,10 @@ class CorrespondenceController < ApplicationController
     end
   end
 
-
-
-
   def topic
     @correspondence = Correspondence.new
   end
-  
+
   def search
     @correspondence = Correspondence.new(topic: search_params[:topic])
     if @correspondence.topic_present?
@@ -36,6 +33,18 @@ class CorrespondenceController < ApplicationController
       @search_result = @search_api_client.search
     else
       render :topic
+    end
+  end
+
+  def authenticate
+    @correspondence = Correspondence.where(uuid: params[:uuid]).first
+    if @correspondence.nil?
+      render file: '/public/404.html', status: 404, layout: false
+    elsif @correspondence.authenticated?
+      render template: 'correspondence/already_authenticated'
+    else
+      @correspondence.authenticate!
+      EmailCorrespondenceJob.perform_later(@correspondence)
     end
   end
 

--- a/app/models/correspondence.rb
+++ b/app/models/correspondence.rb
@@ -2,10 +2,12 @@
 #
 # Table name: correspondence
 #
-#  id         :integer          not null, primary key
-#  content    :jsonb
-#  created_at :datetime         not null
-#  updated_at :datetime         not null
+#  id               :integer          not null, primary key
+#  content          :jsonb
+#  created_at       :datetime         not null
+#  updated_at       :datetime         not null
+#  uuid             :string
+#  authenticated_at :datetime
 #
 
 class Correspondence < ActiveRecord::Base
@@ -15,7 +17,8 @@ class Correspondence < ActiveRecord::Base
                         :email,
                         :category,
                         :topic,
-                        :message
+                        :message,
+                        :uuid
 
   validates :email, confirmation: { case_sensitive: false }
 
@@ -47,5 +50,16 @@ class Correspondence < ActiveRecord::Base
   def topic_present?
     errors['topic'] << " can't be blank" unless topic.present?
     topic.present?
+  end
+
+  def authenticated?
+    !self.authenticated_at.nil?
+  end
+
+  def authenticate!
+    unless authenticated?
+      self.authenticated_at = Time.now
+      save!
+    end
   end
 end

--- a/app/services/correspondence_creator.rb
+++ b/app/services/correspondence_creator.rb
@@ -14,8 +14,8 @@ class CorrespondenceCreator
 
   def create_correspondence(params)
     correspondence = Correspondence.new(params)
+    correspondence.uuid = SecureRandom.uuid
     if correspondence.save
-      EmailCorrespondenceJob.perform_later(correspondence)
       EmailConfirmationJob.perform_later(correspondence)
       @result = :success
     else

--- a/app/views/confirmation_mailer/new_confirmation.html.slim
+++ b/app/views/confirmation_mailer/new_confirmation.html.slim
@@ -1,1 +1,3 @@
-= t('.confirmation_html', full_name: @correspondence.name)
+= t('.confirmation_html',
+        full_name: @correspondence.name,
+        authentication_link: correspondence_authentication_url(@correspondence.uuid))

--- a/app/views/correspondence/already_authenticated.html.slim
+++ b/app/views/correspondence/already_authenticated.html.slim
@@ -1,0 +1,10 @@
+- content_for :page_title do
+  = t('page_title.authentication_confirmation')
+
+= render partial: 'layouts/header', locals: {page_heading: t('common.service_name')}
+
+
+h2.heading-medium
+  | This request has already been authenticated.
+
+| Your request is being actioned by one of our teams.

--- a/app/views/correspondence/authenticate.html.slim
+++ b/app/views/correspondence/authenticate.html.slim
@@ -1,0 +1,10 @@
+- content_for :page_title do
+  = t('page_title.authentication_confirmation')
+
+= render partial: 'layouts/header', locals: {page_heading: t('common.service_name')}
+
+
+h2.heading-medium
+  | Thank you for authenticating your request.
+
+| Your request will now be actioned by one of our teams.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -160,13 +160,18 @@ en:
       Feedback form - Contact the Ministry of Justice
     feedback_confirm: |
       Feedback confirmation - Contact the Ministry of Justice
+    authentication_confirmation: |
+      Authentication confirmation
 
   confirmation_mailer:
     new_confirmation:
       confirmation_html: |
         <p class="p--double-lines">To %{full_name}<br>
         Thank you for contacting the Ministry of Justice.<br>
-        Our team will be checking what you have sent us shortly.<br>
+        We have received a request for information from someone who gave this email address.</p>
+        <p>If this was you, please click on the following link to athenticate the request:</p>
+        <p><a href="%{authentication_link}">%{authentication_link}</a></p>
+        <p>Once you authenticate this request by clicking on the link above, our team will check what you have sent us.<br>
         We aim to get back to you within 1 month, if we are able to respond to you.<br>
         MOJ team</p>
         <span class="p--double-lines">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,6 +7,8 @@ resources :feedback, only: [:new, :create]
 get '/correspondence' => 'correspondence#topic'
 get '/correspondence/topic' => 'correspondence#topic'
 get '/correspondence/search' => 'correspondence#search'
+get '/correspondence/authenticate/:uuid' => 'correspondence#authenticate', as: 'correspondence_authentication'
+
 
 get '/feedback' => 'feedback#new'
 

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -38,7 +38,7 @@ smoke_tests:
   first_read_wait: 3
   max_wait_time: 600
 aaq_feedback_email: feedback@localhost
-aaq_email_url: http://localhost/
+aaq_email_url: http://localhost:3000
 
 # These are set in run.sh
 git_source:  Git Source Not Available

--- a/db/migrate/20170412140235_add_authenticated_and_uuid_to_correspondence.rb
+++ b/db/migrate/20170412140235_add_authenticated_and_uuid_to_correspondence.rb
@@ -1,0 +1,8 @@
+class AddAuthenticatedAndUuidToCorrespondence < ActiveRecord::Migration[5.0]
+  def change
+    add_column :correspondence, :uuid, :string
+    add_column :correspondence, :authenticated_at, :datetime, default: nil
+
+    add_index(:correspondence, :uuid, unique: true)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,15 +10,18 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20161027142803) do
+ActiveRecord::Schema.define(version: 20170412140235) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
   create_table "correspondence", force: :cascade do |t|
     t.jsonb    "content"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at",       null: false
+    t.datetime "updated_at",       null: false
+    t.string   "uuid"
+    t.datetime "authenticated_at"
+    t.index ["uuid"], name: "index_correspondence_on_uuid", unique: true, using: :btree
   end
 
   create_table "feedback", force: :cascade do |t|

--- a/lib/tasks/sidekiq.rake
+++ b/lib/tasks/sidekiq.rake
@@ -1,0 +1,26 @@
+namespace :sidekiq do
+
+  desc 'Display list of sidekiq queues and waiting jobs'
+  task status: :environment do
+
+    require 'sidekiq/api'
+
+    queue_names = Sidekiq::Queue.all.map(&:name)
+
+    queue_names.each do |qn|
+      q = Sidekiq::Queue.new(qn)
+      puts "Queue name: #{qn}"
+      if q.size == 0
+        puts "   No queued jobs"
+      else
+        q.each do |job|
+          job_detail = job.args.first
+          puts "   Job id: #{job_detail['job_id']}   #{job_detail['job_class']}   args: #{job_detail['arguments'].inspect}"
+        end
+      end
+      puts "  "
+    end
+
+  end
+end
+

--- a/spec/factories/correspondence.rb
+++ b/spec/factories/correspondence.rb
@@ -2,10 +2,12 @@
 #
 # Table name: correspondence
 #
-#  id         :integer          not null, primary key
-#  content    :jsonb
-#  created_at :datetime         not null
-#  updated_at :datetime         not null
+#  id               :integer          not null, primary key
+#  content          :jsonb
+#  created_at       :datetime         not null
+#  updated_at       :datetime         not null
+#  uuid             :string
+#  authenticated_at :datetime
 #
 
 FactoryGirl.define do
@@ -16,5 +18,10 @@ FactoryGirl.define do
     category 'general_enquiries'
     topic { (Faker::Hipster.sentence 4, false, 2)[0..59] }
     message { Faker::Lorem.paragraph(1) }
+    uuid { SecureRandom.uuid }
+
+    trait :authenticated do
+      authenticated_at 10.minutes.ago
+    end
   end
 end

--- a/spec/features/correspondence_authentication_spec.rb
+++ b/spec/features/correspondence_authentication_spec.rb
@@ -1,0 +1,31 @@
+require 'rails_helper'
+
+feature 'Authenticate a correspondence item' do
+
+  given(:uuid) { 'cce5cc97-426b-4e96-8e9a-33da374f8e29' }
+  given(:frozen_time) { Time.new(2017, 4, 13, 14, 15, 16) }
+
+  scenario 'User authenticates an unauthenticated correspondence item' do
+    correspondence = create :correspondence, uuid: uuid
+    Timecop.freeze frozen_time do
+      visit "/correspondence/authenticate/#{uuid}"
+      expect(page).to have_content('Thank you for authenticating your request.')
+      expect(page).to have_content('Your request will now be actioned by one of our teams.')
+      expect(correspondence.reload.authenticated_at).to eq frozen_time
+    end
+  end
+
+  scenario 'User authenticates an already authenticated correspondence item' do
+    authentication_time = Time.new(2017, 3, 2, 0, 3, 28)
+    correspondence = create :correspondence, uuid: uuid, authenticated_at: authentication_time
+    visit "/correspondence/authenticate/#{uuid}"
+    expect(page).to have_content('This request has already been authenticated.')
+    expect(page).to have_content('Your request is being actioned by one of our teams.')
+    expect(correspondence.reload.authenticated_at).to eq authentication_time
+  end
+
+  scenario 'User attempts to authenticate with invalid uuid' do
+    visit "/correspondence/authenticate/abcd-efgh-23454"
+    expect(page).to have_http_status(404)
+  end
+end

--- a/spec/features/send_correspondence_spec.rb
+++ b/spec/features/send_correspondence_spec.rb
@@ -93,7 +93,6 @@ feature 'Submit a general enquiry' do
       message: message,
       topic: topic_with_results
     )
-    expect(EmailCorrespondenceJob).to have_been_enqueued.with(Correspondence.last)
     expect(EmailConfirmationJob).to have_been_enqueued.with(Correspondence.last)
 
     expect(page).to have_link(
@@ -151,7 +150,6 @@ feature 'Submit a general enquiry' do
                                        message: message,
                                        topic: 'AbccdefghijkLmnopqrstuvwxyz'
                                    )
-    expect(EmailCorrespondenceJob).to have_been_enqueued.with(Correspondence.last)
     expect(EmailConfirmationJob).to have_been_enqueued.with(Correspondence.last)
   end
 

--- a/spec/mailers/confirmation_mailer_spec.rb
+++ b/spec/mailers/confirmation_mailer_spec.rb
@@ -21,8 +21,10 @@ RSpec.describe ConfirmationMailer, type: :mailer do
   let(:expected_message)  do
     [ "To #{@correspondence.name}",
       'Thank you for contacting the Ministry of Justice.',
-      'Our team will be checking what you have sent us shortly.',
-      'We aim to get back to you within 1 month, if we are able to respond to you',
+      'We have received a request for information from someone who gave this email address.',
+      'If this was you, please click on the following link to athenticate the request:',
+      'Once you authenticate this request by clicking on the link above, our team will check what you have sent us.',
+      'We aim to get back to you within 1 month, if we are able to respond to you.',
       'MOJ team',
       'Do not reply to this email.',
       'This address is not checked by the Ministry of Justice'

--- a/spec/models/correspondence_spec.rb
+++ b/spec/models/correspondence_spec.rb
@@ -2,10 +2,12 @@
 #
 # Table name: correspondence
 #
-#  id         :integer          not null, primary key
-#  content    :jsonb
-#  created_at :datetime         not null
-#  updated_at :datetime         not null
+#  id               :integer          not null, primary key
+#  content          :jsonb
+#  created_at       :datetime         not null
+#  updated_at       :datetime         not null
+#  uuid             :string
+#  authenticated_at :datetime
 #
 
 require 'rails_helper'
@@ -27,6 +29,7 @@ RSpec.describe Correspondence, type: :model do
     it { should validate_presence_of     :name }
     it { should validate_presence_of     :email }
     it { should validate_presence_of     :category }
+    it { should validate_presence_of     :uuid }
     it do
       should validate_presence_of(:topic).
           with_message(
@@ -76,6 +79,45 @@ RSpec.describe Correspondence, type: :model do
         expect(correspondence.errors[:topic]).to eq [" can't be blank"]
       end
     end
+  end
+
+  describe '#authenticated?' do
+    context 'unauthenticated' do
+      it 'returns false' do
+        correspondence = build :correspondence
+        expect(correspondence.authenticated?).to be false
+      end
+    end
+
+    context 'authenticated' do
+      it 'returns true' do
+        correspondence = build :correspondence, :authenticated
+        expect(correspondence.authenticated?).to be true
+      end
+    end
+  end
+
+  describe 'autenticate!' do
+    let(:frozen_time) { Time.new(2017, 4, 13, 22, 33, 44) }
+
+    context 'unauthenticated' do
+      it 'updates authenticated_at with current time' do
+        Timecop.freeze frozen_time do
+          correspondence = build :correspondence
+          correspondence.authenticate!
+          expect(correspondence.authenticated_at).to eq frozen_time
+        end
+      end
+    end
+
+    context 'authenticated' do
+      it 'does not update the authenticated at time' do
+        correspondence = build :correspondence, authenticated_at: frozen_time
+        correspondence.authenticate!
+        expect(correspondence.authenticated_at).to eq frozen_time
+      end
+    end
+
   end
 
 

--- a/spec/services/correspondence_creator_spec.rb
+++ b/spec/services/correspondence_creator_spec.rb
@@ -35,12 +35,7 @@ describe CorrespondenceCreator do
         expect(creator.result).to eq :success
       end
 
-      it 'sends correspondence eamil' do
-        expect(EmailCorrespondenceJob).to receive(:perform_later).with(instance_of(Correspondence))
-        CorrespondenceCreator.new(params)
-      end
-
-      it 'sends confirmation eamil' do
+      it 'sends confirmation email' do
         expect(EmailConfirmationJob).to receive(:perform_later).with(instance_of(Correspondence))
         CorrespondenceCreator.new(params)
       end
@@ -49,6 +44,12 @@ describe CorrespondenceCreator do
         expect {
           CorrespondenceCreator.new(params)
         }.to change {Correspondence.count }.by(1)
+      end
+
+      it 'adds a uuid' do
+        allow(SecureRandom).to receive(:uuid).and_return('ffffffff-eeee-dddd-cccc-bbbbbbbbbbb')
+        CorrespondenceCreator.new(params)
+        expect(Correspondence.last.uuid).to eq 'ffffffff-eeee-dddd-cccc-bbbbbbbbbbb'
       end
     end
 


### PR DESCRIPTION
This PR adds an extra step to the process of a member of the public submitting
a correspondence item.  When the item is created, a mail with a URL comprising the
item's uuid is sent to the specified email address, and the item is not consiered
authenticated until the user has clicked on the link in the email.