### PR TITLE
CT-673 Update Nokogiri gem security

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -208,7 +208,7 @@ GEM
     net-http-digest_auth (1.4)
     net-http-persistent (2.9.4)
     nio4r (2.0.0)
-    nokogiri (1.7.0.1)
+    nokogiri (1.7.1)
       mini_portile2 (~> 2.1.0)
     notiffany (0.1.1)
       nenv (~> 0.1)


### PR DESCRIPTION
Advisory: CVE-2016-4658

URL: sparklemotion/nokogiri#1615

Solution: upgrade to >= 1.7.1