### PR TITLE
CT-655 prevent dupe submission

### DIFF
--- a/app/controllers/correspondence_controller.rb
+++ b/app/controllers/correspondence_controller.rb
@@ -11,7 +11,7 @@ class CorrespondenceController < ApplicationController
     @correspondence = creator.correspondence
     case creator.result
     when :success
-      render 'correspondence/confirmation'
+      redirect_to correspondence_confirmation_path(@correspondence)
     when :no_op
       redirect_to Settings.moj_home_page
     when :validation_error
@@ -19,6 +19,10 @@ class CorrespondenceController < ApplicationController
       @search_result = @search_api_client.search
       render :search
     end
+  end
+
+  def confirmation
+    @correspondence = Correspondence.find(params[:id])
   end
 
   def topic

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,6 +8,7 @@ get '/correspondence' => 'correspondence#topic'
 get '/correspondence/topic' => 'correspondence#topic'
 get '/correspondence/search' => 'correspondence#search'
 get '/correspondence/authenticate/:uuid' => 'correspondence#authenticate', as: 'correspondence_authentication'
+get '/correspondence/confirmation/:id' => 'correspondence#confirmation', as: 'correspondence_confirmation'
 
 
 get '/feedback' => 'feedback#new'

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -37,7 +37,7 @@ smoke_tests:
   password: 'password'
   site_url: 'http://localhost:3000'
   first_read_wait: 3
-  max_wait_time: 240
+  max_wait_time: 600
 aaq_feedback_email: feedback@localhost
 aaq_email_url: http://localhost:3000
 

--- a/spec/controllers/correspondence_controller_spec.rb
+++ b/spec/controllers/correspondence_controller_spec.rb
@@ -123,8 +123,10 @@ RSpec.describe CorrespondenceController, type: :controller do
           .to have_been_enqueued.with(Correspondence.last)
       end
 
-      it 'renders the :confirmation template' do
-        expect(post :create, params: params).to render_template(:confirmation)
+      it 'redirects to the confirmation action' do
+        post :create, params: params
+        correspondence = Correspondence.last
+        expect(response).to redirect_to(correspondence_confirmation_path(correspondence))
       end
     end
 
@@ -187,6 +189,14 @@ RSpec.describe CorrespondenceController, type: :controller do
       end
 
       it { should respond_with 500 }
+    end
+  end
+
+  describe 'GET confirmation' do
+    it 'assigns the correspondence item' do
+      item = create :correspondence
+      get :confirmation, params: { id: item.id }
+      expect(assigns(:correspondence)).to eq item
     end
   end
 end

--- a/spec/views/correspondence/confirmation_html_slim_spec.rb
+++ b/spec/views/correspondence/confirmation_html_slim_spec.rb
@@ -1,0 +1,14 @@
+require 'rails_helper'
+
+describe 'correspondence/confirmation.html.slim' do
+
+  it 'displays the creators email address' do
+    item = create :correspondence, email: 'person@example.com'
+    assign(:correspondence, item)
+
+    render
+
+    expect(rendered).to have_text('One more step...')
+    expect(rendered).to have_text("We've sent an email to person@example.com")
+  end
+end


### PR DESCRIPTION
This PR fixes a bug whereby reloading the confirmation page would re-submit the correspondence request.