### PR TITLE
Fix smoke tests and address security vulnerablity

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -217,7 +217,7 @@ GEM
       jwt (~> 1.5)
     ntlm-http (0.1.1)
     parallel (1.12.1)
-    parser (2.5.0.4)
+    parser (2.5.0.5)
       ast (~> 2.4.0)
     pg (0.18.4)
     poltergeist (1.13.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -76,6 +76,7 @@ GEM
       activesupport (>= 3.0)
       deep_merge (~> 1.1.1)
     connection_pool (2.2.0)
+    crass (1.0.3)
     css_parser (1.4.5)
       addressable
     curb (0.9.3)
@@ -183,7 +184,8 @@ GEM
       activesupport (>= 4.0)
       logstash-event (~> 1.2.0)
       request_store
-    loofah (2.0.3)
+    loofah (2.2.2)
+      crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
     lumberjack (1.0.10)
     mail (2.6.4)


### PR DESCRIPTION
## Broken smoke tests:
It would appear that the author of Parser removed a version of the Gem
that we were using. This caused the smoke tests to fail twice over the
weekend.

## Security Vulnerability:
Known vulnerability found
CVE-2018-8048
Moderate severity
Loofah allows non-whitelisted attributes to be present in sanitized
output when input with specially-crafted HTML fragments

Gemfile.lock update suggested:
loofah ~> 2.2.1
Always verify the validity and compatibility of suggestions with your codebase.

flavorjones/loofah#144