### PR TITLE
Fixes assets not minifying

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -46,6 +46,6 @@ RUN bundle config --global frozen 1 \
 
 COPY . .
 
-RUN bundle exec rake assets:precompile SECRET_KEY_BASE=required_but_does_not_matter_for_assets
+RUN RAILS_ENV=production bundle exec rake assets:clean assets:precompile SECRET_KEY_BASE=required_but_does_not_matter_for_assets
 
 ENTRYPOINT ["./run.sh"]


### PR DESCRIPTION
When compiling assets you need to specify which rails env those assets will be used in else it defaults to develop. In develop environment, it does not minify or concatenate the assets that the service is using.