### PR TITLE
CT-2867 users can no longer inspect emails from previous users

### DIFF
--- a/app/controllers/correspondence_controller.rb
+++ b/app/controllers/correspondence_controller.rb
@@ -22,7 +22,7 @@ class CorrespondenceController < ApplicationController
   end
 
   def confirmation
-    @correspondence = Correspondence.find(params[:id])
+    @correspondence = Correspondence.find_by_uuid(params[:uuid])
   end
 
   def topic

--- a/app/controllers/correspondence_controller.rb
+++ b/app/controllers/correspondence_controller.rb
@@ -11,7 +11,7 @@ class CorrespondenceController < ApplicationController
     @correspondence = creator.correspondence
     case creator.result
     when :success
-      redirect_to correspondence_confirmation_path(@correspondence)
+      redirect_to correspondence_confirmation_path(@correspondence.uuid)
     when :no_op
       redirect_to Settings.moj_home_page
     when :validation_error

--- a/build.sh
+++ b/build.sh
@@ -47,7 +47,7 @@ function _build() {
 
   # 3. Get a logged in context so we can push images to the ECR
   p "Docker login to registry (ECR)..."
-  $(aws ecr --profile "$aws_profile" get-login --no-include-email --region "$region" --profile "$aws_profile")
+  docker login -u AWS -p $(aws ecr get-login-password --profile "$aws_profile" --region "$region") $docker_endpoint
 
   # 4. Compose the URL for the remote git object we'll use as the Docker build context
   p "Using git repository as Docker context"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,7 +9,7 @@ get '/correspondence/topic' => 'correspondence#topic'
 get '/correspondence/search' => 'correspondence#search'
 get '/correspondence/t_and_c' => 'correspondence#t_and_c'
 get '/correspondence/authenticate/:uuid' => 'correspondence#authenticate', as: 'correspondence_authentication'
-get '/correspondence/confirmation/:id' => 'correspondence#confirmation', as: 'correspondence_confirmation'
+get '/correspondence/confirmation/:uuid' => 'correspondence#confirmation', as: 'correspondence_confirmation'
 
 get '/feedback' => 'feedback#new'
 

--- a/spec/controllers/correspondence_controller_spec.rb
+++ b/spec/controllers/correspondence_controller_spec.rb
@@ -129,7 +129,7 @@ RSpec.describe CorrespondenceController, type: :controller do
       it 'redirects to the confirmation action' do
         post :create, params: params
         correspondence = Correspondence.last
-        expect(response).to redirect_to(correspondence_confirmation_path(correspondence))
+        expect(response).to redirect_to(correspondence_confirmation_path(correspondence.uuid))
       end
     end
 

--- a/spec/controllers/correspondence_controller_spec.rb
+++ b/spec/controllers/correspondence_controller_spec.rb
@@ -198,7 +198,7 @@ RSpec.describe CorrespondenceController, type: :controller do
   describe 'GET confirmation' do
     it 'assigns the correspondence item' do
       item = create :correspondence
-      get :confirmation, params: { id: item.id }
+      get :confirmation, params: { uuid: item.uuid }
       expect(assigns(:correspondence)).to eq item
     end
   end


### PR DESCRIPTION
We discovered a potential leak where the confirmation page used the sequential Correspondence.id as the URL parameter for the confirmation page when sending a contact email to MOJ. If the user started decrementing the integer in the URL, they could browse the email addresses of previous users. This PR changes the redirect from create, the confirmation route and the confirmation controller action to use the existing UUID field (used for the email -> authenticate step) instead of the ID in order to display the confirmation code. This has loads of entropy and is acceptably secure for this purpose.  