### PR TITLE
CT-2688 Upgrade rack to version 2.2.3

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -20,12 +20,13 @@ gem 'mechanize', '~> 2.7.6'
 gem 'puma', '~> 4.3'
 gem 'pg', '~> 1.2'
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
+gem "rack", ">= 2.1.4"
 gem 'rails', '~> 5.2.4', '>= 5.2.4.2'
 # Reduces boot times through caching; required in config/boot.rb
 gem 'bootsnap', '>= 1.1.0', require: false
 gem 'responders', '~> 2.3'
 gem 'sass-rails', '~> 6.0'
-gem 'sidekiq', '~> 5.1'
+gem 'sidekiq', '~> 6.0'
 gem 'slim-rails', '~> 3.2'
 # Used for the GOVUK Search API
 gem 'stopwords-filter', require: 'stopwords'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -83,7 +83,7 @@ GEM
     config (2.2.1)
       deep_merge (~> 1.2, >= 1.2.1)
       dry-validation (~> 1.0, >= 1.0.0)
-    connection_pool (2.2.2)
+    connection_pool (2.2.3)
     crass (1.0.6)
     curb (0.9.10)
     deep_merge (1.2.1)
@@ -188,7 +188,7 @@ GEM
     http-cookie (1.0.3)
       domain_name (~> 0.5)
     http_parser.rb (0.6.0)
-    i18n (1.8.2)
+    i18n (1.8.3)
       concurrent-ruby (~> 1.0)
     i18n-tasks (0.9.31)
       activesupport (>= 4.0.2)
@@ -224,7 +224,7 @@ GEM
       activesupport (>= 4.0)
       logstash-event (~> 1.2.0)
       request_store
-    loofah (2.5.0)
+    loofah (2.6.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
     lumberjack (1.2.4)
@@ -256,7 +256,7 @@ GEM
     net-http-persistent (4.0.0)
       connection_pool (~> 2.2)
     nio4r (2.5.2)
-    nokogiri (1.10.9)
+    nokogiri (1.10.10)
       mini_portile2 (~> 2.4.0)
     notiffany (0.1.3)
       nenv (~> 0.1)
@@ -282,9 +282,7 @@ GEM
     public_suffix (4.0.5)
     puma (4.3.5)
       nio4r (~> 2.0)
-    rack (2.0.9)
-    rack-protection (2.0.8.1)
-      rack
+    rack (2.2.3)
     rack-test (1.1.0)
       rack (>= 1.0, < 3)
     rails (5.2.4.3)
@@ -324,7 +322,7 @@ GEM
     rb-inotify (0.10.1)
       ffi (~> 1.0)
     rb-readline (0.5.5)
-    redis (4.1.4)
+    redis (4.2.1)
     regexp_parser (1.7.0)
     request_store (1.5.0)
       rack (>= 1.4)
@@ -380,11 +378,10 @@ GEM
       childprocess (>= 0.5, < 4.0)
       rubyzip (>= 1.2.2)
     shellany (0.0.1)
-    sidekiq (5.2.8)
-      connection_pool (~> 2.2, >= 2.2.2)
-      rack (< 2.1.0)
-      rack-protection (>= 1.5.0)
-      redis (>= 3.3.5, < 5)
+    sidekiq (6.1.0)
+      connection_pool (>= 2.2.2)
+      rack (~> 2.0)
+      redis (>= 4.2.0)
     simplecov (0.13.0)
       docile (~> 1.1.0)
       json (>= 1.8, < 3)
@@ -437,9 +434,9 @@ GEM
       bindex (>= 0.4.0)
       railties (>= 5.0)
     webrobots (0.1.2)
-    websocket-driver (0.7.1)
+    websocket-driver (0.7.3)
       websocket-extensions (>= 0.1.0)
-    websocket-extensions (0.1.4)
+    websocket-extensions (0.1.5)
     xpath (3.2.0)
       nokogiri (~> 1.8)
 
@@ -482,6 +479,7 @@ DEPENDENCIES
   pry
   pry-byebug
   puma (~> 4.3)
+  rack (>= 2.1.4)
   rails (~> 5.2.4, >= 5.2.4.2)
   rails-controller-testing
   rb-readline (~> 0.5.4)
@@ -492,7 +490,7 @@ DEPENDENCIES
   sass-rails (~> 6.0)
   selenium-webdriver (~> 3.14)
   shoulda-matchers!
-  sidekiq (~> 5.1)
+  sidekiq (~> 6.0)
   site_prism (~> 3.1)
   slim-rails (~> 3.2)
   spring
@@ -504,9 +502,6 @@ DEPENDENCIES
   tzinfo-data
   uglifier (>= 1.3.0)
   web-console
-
-RUBY VERSION
-   ruby 2.5.1p57
 
 BUNDLED WITH
    1.17.1


### PR DESCRIPTION
https://github.com/advisories/GHSA-j6w9-fv6q-3q52
CVE-2020-8184

high severity
Vulnerable versions: < 2.1.4
Patched version: 2.1.4
A reliance on cookies without validation/integrity check security vulnerability exists in rack < 2.2.3, rack < 2.1.4 that makes it is possible for an attacker to forge a secure or host-only cookie prefix.

Upgraded sidekiq and other dependencies to allow this update