### PR TITLE
CT-3118 Add reusable alert banner for covid19

### DIFF
--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -35,9 +35,9 @@
 @import 'elements/phase-banner';
 @import 'elements/components';
 
-
 // grid system
 @import "susy";
+@import "moj/alert_banner";
 @import "moj/config";
 
 // custom mixins & helpers

--- a/app/assets/stylesheets/moj/_alert_banner.scss
+++ b/app/assets/stylesheets/moj/_alert_banner.scss
@@ -1,0 +1,24 @@
+.alert-banner {
+  @extend %site-width-container;
+  border: 4px solid $govuk-blue;
+  padding: 2rem 2rem 1rem;
+  margin-top: 2em;
+  margin-bottom: 2em;
+  box-sizing: border-box;
+  position: relative;
+
+  &__icon {
+    color: $govuk-blue;
+    position: absolute;
+    left: 2rem;
+    top: 2rem;
+  }
+
+  &__info {
+    padding: 5px 0 0 55px;
+
+    @include media(tablet) {
+      font-size: 19px;
+    }
+  }
+}

--- a/app/views/layouts/_alert_banner.html.slim
+++ b/app/views/layouts/_alert_banner.html.slim
@@ -1,0 +1,6 @@
+.alert-banner
+  svg.alert-banner__icon fill="currentColor" role="presentation" focusable="false" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 25 25" height="40" width="40"
+    path d="M13.7,18.5h-2.4v-2.4h2.4V18.5z  M12.5,13.7c-0.7,0-1.2-0.5-1.2-1.2V7.7c0-0.7,0.5-1.2,1.2-1.2s1.2,0.5,1.2,1.2v4.8
+C13.7,13.2,13.2,13.7,12.5,13.7z M12.5,0.5c-6.6,0-12,5.4-12,12s5.4,12,12,12s12-5.4,12-12S19.1,0.5,12.5,0.5z"
+  p.alert-banner__info
+    = t('common.alert_banner')

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -20,6 +20,7 @@
   = csrf_meta_tags
   #page
     = render partial: 'layouts/phase_banner'
+    = render partial: 'layouts/alert_banner'
   .primary-nav-bar
   main#content
     = render partial: 'layouts/flashes' unless flash.empty?

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -82,6 +82,7 @@ en:
 
   common:
     accessibility: Accessibility
+    alert_banner: "We are unable to respond to documents sent by post because of coronavirus (COVID-19). When using this online contact form please be aware that responses will take longer than usual."
     error: error
     phase_banner: |
       This is a new service – your feedback will help us to improve it.


### PR DESCRIPTION
## Description
A reusable banner with a message notifying users of a delayed response. Didn't add tests as it's temporary (hopefully!) - but can consider.

## Self-review checklist
<!-- Action these things before requesting reviews -->
* [ ] (1) Quick stakeholder demo done OR
* [x] (2) ...bug with before and after screenshots
* [x] (3) Tests passing
* [x] (4) Branch ready to be merged (not work in progress)
* [x] (5) No superfluous changes in diff
* [x] (6) No TODO's without new ticket numbers
* [x] (7) PR Prefixed with ticket number e.g. `CT-7654 ...`

### Screenshots
<!-- Screenshots of the new changes if appropriate -->
![image](https://user-images.githubusercontent.com/22935203/94557123-0e94ae00-0256-11eb-8ab4-195669006a13.png)

### Related JIRA tickets
https://dsdmoj.atlassian.net/browse/CT-3118

### Deployment
n/a

### Manual testing instructions
All pages should have the banner on top
