### PR TITLE
CT-3208 Add more specificity to link to keep it white

### DIFF
--- a/app/assets/stylesheets/moj/_govuk_overrides.scss
+++ b/app/assets/stylesheets/moj/_govuk_overrides.scss
@@ -37,3 +37,7 @@ strong {
 .gov_uk_date .form-hint{
   margin-bottom: 0;
 }
+
+a.button:link {
+  color: #fff;
+}


### PR DESCRIPTION
## Description
Make the Start now link keep text white even when pressed.

## Self-review checklist
<!-- Action these things before requesting reviews -->
* [ ] (1) Quick stakeholder demo done OR
* [x] (2) ...bug with before and after screenshots
* [x] (3) Tests passing
* [x] (4) Branch ready to be merged (not work in progress)
* [x] (5) No superfluous changes in diff
* [x] (6) No TODO's without new ticket numbers
* [x] (7) PR Prefixed with ticket number e.g. `CT-7654 ...`

### Screenshots
Before: 
![image](https://user-images.githubusercontent.com/22935203/100476943-dc30f100-30de-11eb-93e1-fc16c9506eb5.png)
After: 
![image](https://user-images.githubusercontent.com/22935203/100477121-58c3cf80-30df-11eb-8b13-6781d12dcbd1.png)


### Related JIRA tickets
https://dsdmoj.atlassian.net/browse/CT-3208

### Deployment
n/a

### Manual testing instructions
Click on start now and keep the mouse button down, or tab to it. The text should stay white instead of blue, so keeping AA/AAA contrast. https://staging.contact-moj.service.justice.gov.uk/
