### PR TITLE
CT-3414 restore original banner

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -82,7 +82,7 @@ en:
 
   common:
     accessibility: Accessibility
-    alert_banner_html: "This service will be down for essential maintenance between 12pm and 2pm on Monday 8th February. You will not have access during this period. <br><br>We are unable to respond to documents sent by post because of coronavirus (COVID-19). When using this online contact form please be aware that responses will take longer than usual."
+    alert_banner_html: "We are unable to respond to documents sent by post because of coronavirus (COVID-19). When using this online contact form please be aware that responses will take longer than usual."
     error: error
     phase_banner: |
       This is a new service – your feedback will help us to improve it.


### PR DESCRIPTION
## Description
Restore original banner before RDS upgrade

## Self-review checklist
<!-- Action these things before requesting reviews -->
* [ ] (1) Quick stakeholder demo done OR
* [x] (2) ...bug with before and after screenshots
* [ ] (3) Tests passing
* [x] (4) Branch ready to be merged (not work in progress)
* [x] (5) No superfluous changes in diff
* [x] (6) No TODO's without new ticket numbers
* [x] (7) PR Prefixed with ticket number e.g. `CT-7654 ...`

### Screenshots
was
![image](https://user-images.githubusercontent.com/22935203/107058839-01239d80-67cd-11eb-8a84-9f38874a1d9a.png)

is
![image](https://user-images.githubusercontent.com/22935203/107058775-eea96400-67cc-11eb-9b06-c88d6d17f7de.png)

### Related JIRA tickets
(part of RDS upgrade) https://dsdmoj.atlassian.net/browse/CT-3414

### Deployment
as part of production with sql client update - post RDS upgrade

### Manual testing instructions
should see banner from before 5th feb 