### PR TITLE
CT-3642 Replace poltergeist with webdriver/chromedriver

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -35,6 +35,7 @@ gem 'uglifier', '>= 1.3.0'
 gem 'sprockets', '~> 3.7.2'
 # Alpine does not include zoneinfo files (probably) - it asked for tinfo-data, so bundle the tzinfo-data gem
 gem 'tzinfo-data'
+gem 'webdrivers', '~> 4.4'
 # Use Redis adapter to run Action Cable in production
 # gem 'redis', '~> 3.0'
 # Use ActiveModel has_secure_password
@@ -44,14 +45,14 @@ gem 'tzinfo-data'
 
 group :test do
   gem 'capybara', '>= 3.35.3'
-  gem 'capybara-screenshot', '>= 1.0.25'
+  gem 'capybara-selenium'
+  gem 'capybara-screenshot'
   gem 'codeclimate-test-reporter', '~> 1.0'
   gem 'i18n-tasks', '~> 0.9.34'
   gem 'rails-controller-testing', '>= 1.0.5'
   gem 'selenium-webdriver', '~> 3.14'
   gem 'shoulda-matchers', :git => 'https://github.com/thoughtbot/shoulda-matchers.git'
   gem 'site_prism', '~> 3.7', '>= 3.7.1'
-  gem 'poltergeist', '~> 1.18', '>= 1.18.1'
   gem 'timecop', '~> 0.9'
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -74,8 +74,10 @@ GEM
     capybara-screenshot (1.0.25)
       capybara (>= 1.0, < 4)
       launchy
+    capybara-selenium (0.0.6)
+      capybara
+      selenium-webdriver
     childprocess (3.0.0)
-    cliver (0.3.2)
     codeclimate-test-reporter (1.0.9)
       simplecov (<= 0.13)
     coderay (1.1.3)
@@ -261,10 +263,6 @@ GEM
     parser (3.0.1.1)
       ast (~> 2.4.1)
     pg (1.2.3)
-    poltergeist (1.18.1)
-      capybara (>= 2.1, < 4)
-      cliver (~> 0.3.1)
-      websocket-driver (>= 0.2.0)
     pry (0.13.1)
       coderay (~> 1.1)
       method_source (~> 1.0)
@@ -440,6 +438,10 @@ GEM
       activemodel (>= 5.0)
       bindex (>= 0.4.0)
       railties (>= 5.0)
+    webdrivers (4.6.0)
+      nokogiri (~> 1.6)
+      rubyzip (>= 1.3.0)
+      selenium-webdriver (>= 3.0, < 4.0)
     webrick (1.7.0)
     webrobots (0.1.2)
     websocket-driver (0.7.3)
@@ -459,7 +461,8 @@ DEPENDENCIES
   brakeman
   byebug
   capybara (>= 3.35.3)
-  capybara-screenshot (>= 1.0.25)
+  capybara-screenshot
+  capybara-selenium
   codeclimate-test-reporter (~> 1.0)
   config
   curb (~> 0.9.11)
@@ -484,7 +487,6 @@ DEPENDENCIES
   mail (~> 2.7.0)
   mechanize (~> 2.8, >= 2.8.1)
   pg (~> 1.2)
-  poltergeist (~> 1.18, >= 1.18.1)
   pry
   pry-byebug
   puma (~> 5.3, >= 5.3.1)
@@ -513,6 +515,7 @@ DEPENDENCIES
   tzinfo-data
   uglifier (>= 1.3.0)
   web-console (>= 3.7.0)
+  webdrivers (~> 4.4)
 
 BUNDLED WITH
-   2.1.4
+   2.2.14

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -9,11 +9,34 @@ abort("The Rails environment is running in production mode!") if Rails.env.produ
 require 'spec_helper'
 require 'rspec/rails'
 require 'capybara/rails'
-require 'capybara/poltergeist'
-
-Capybara.javascript_driver = :poltergeist
+require 'capybara/rspec'
+require 'webdrivers'
 
 Capybara.asset_host = 'http://localhost:3000'
+
+
+Capybara.register_driver :chrome do |app|
+  Capybara::Selenium::Driver.new(app, browser: :chrome)
+end
+
+Capybara.register_driver :headless_chrome do |app|
+  options = Selenium::WebDriver::Chrome::Options.new
+  unless ENV["CHROME_DEBUG"]
+    options.add_argument('--headless')
+    options.add_argument('--disable-gpu')
+    options.add_argument('--no-sandbox')
+    options.add_argument('--start-maximized')
+    options.add_argument('--window-size=1980,2080')
+    options.add_argument('--enable-features=NetworkService,NetworkServiceInProcess')
+  end
+  Capybara::Selenium::Driver.new(app, browser: :chrome, options: options)
+end
+
+Capybara.default_max_wait_time = 4
+Capybara.javascript_driver = :headless_chrome
+
+Capybara.server = :puma, { Silent: true }
+
 
 # Add additional requires below this line. Rails is not loaded until this point!
 


### PR DESCRIPTION
## Description

Replaces Poltergeist with `webdrivers` and chrome as [poltergeist is deprecated](https://github.com/teampoltergeist/poltergeist)

## Self-review checklist
<!-- Action these things before requesting reviews -->
* [ ] (1) Quick stakeholder demo done OR
* [ ] (2) ...bug with before and after screenshots
* [x] (3) Tests passing
* [x] (4) Branch ready to be merged (not work in progress)
* [x] (5) No superfluous changes in diff
* [x] (6) No TODO's without new ticket numbers
* [x] (7) PR Prefixed with ticket number e.g. `CT-7654 ...`

### Related JIRA tickets
[CT-3642](https://dsdmoj.atlassian.net/browse/CT-3642)

### Manual testing instructions
if you haven't already run `rails db:test:prepare`

Then run `bundle exec rspec` to run the tests locally.
