### PR TITLE
CT-4094 Hide covid alert banner

### DIFF
--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -20,7 +20,7 @@
   = csrf_meta_tags
   #page
     = render partial: 'layouts/phase_banner'
-    = render partial: 'layouts/alert_banner'
+    /= render partial: 'layouts/alert_banner'
   .primary-nav-bar
   main#content
     = render partial: 'layouts/flashes' unless flash.empty?


### PR DESCRIPTION
## Description
Remove covid banner and hide Alert banner for now just in case we need to reuse

## Self-review checklist
<!-- Action these things before requesting reviews -->
* [ ] (1) Quick stakeholder demo done OR
* [x] (2) ...bug with before and after screenshots
* [x] (3) Tests passing
* [x] (4) Branch ready to be merged (not work in progress)
* [x] (5) No superfluous changes in diff
* [x] (6) No TODO's without new ticket numbers
* [x] (7) PR Prefixed with ticket number e.g. `CT-7654 ...`

### Screenshots
before:
![image](https://user-images.githubusercontent.com/22935203/154235177-822d0445-0aac-4ebc-a623-d0fb939cfbcc.png)

after:
![image](https://user-images.githubusercontent.com/22935203/154235245-1f9e8da4-1d92-4479-bd13-1d601d3d97ef.png)


### Related JIRA tickets
https://dsdmoj.atlassian.net/browse/CT-4094

### Deployment
n/a

### Manual testing instructions
Try to find the banner on browser
