### PR TITLE
CT-4199 Remove feedback links from accessibility page

### DIFF
--- a/app/controllers/feedback_controller.rb
+++ b/app/controllers/feedback_controller.rb
@@ -8,7 +8,7 @@ class FeedbackController < ApplicationController
 
     if @feedback.save
       FeedbackMailer.new_feedback(@feedback).deliver_later
-      render 'feedback/confirmation'
+      render :confirmation
     else
       render :new
     end

--- a/app/views/pages/accessibility.html.slim
+++ b/app/views/pages/accessibility.html.slim
@@ -33,7 +33,6 @@ h2.start-heading.start-heading--reasons What to do if you cannot access parts of
 p If you need information on this web form in a different format like accessible PDF, large print, easy read, audio recording or braille:
 
 ul.list.list-bullet
-  li Use the <a href="https://contact-moj.service.justice.gov.uk/feedback">feedback form</a>
   li email: <a href="mailto:Contact-MOJ-Support@digital.justice.gov.uk">Contact-MOJ-Support@digital.justice.gov.uk</a>
 
 p We’ll consider your request and get back to you within 7 days.
@@ -43,7 +42,6 @@ h2.start-heading.start-heading--reasons Reporting accessibility problems with th
 p We’re always looking to improve the accessibility of this web form. If you find any problems or think we’re not meeting accessibility requirements:
 
 ul.list.list-bullet
-  li Use the <a href="https://contact-moj.service.justice.gov.uk/feedback">feedback form</a>
   li email: <a href="mailto:Contact-MOJ-Support@digital.justice.gov.uk">Contact-MOJ-Support@digital.justice.gov.uk</a>
 
 h2.start-heading.start-heading--reasons Enforcement procedure

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -36,7 +36,7 @@ en:
     attributes:
       feedback:
         ease_of_use: This online service was easy to use
-        completeness: The online serice enabled me to give all the relevant information
+        completeness: The online service enabled me to give all the relevant information
 
   date:
     formats:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,7 +2,8 @@ Rails.application.routes.draw do
 
 resources :correspondence, only: [:new, :create]
 
-resources :feedback, only: [:new, :create]
+resources :feedback, only: [:new, :create], path: 'give-feedback', path_names: { new: '' }
+get '/give-feedback' => 'feedback#new', as: 'feedback'
 
 get '/correspondence' => 'correspondence#topic'
 get '/correspondence/topic' => 'correspondence#topic'
@@ -11,7 +12,6 @@ get '/correspondence/t_and_c' => 'correspondence#t_and_c'
 get '/correspondence/authenticate/:uuid' => 'correspondence#authenticate', as: 'correspondence_authentication'
 get '/correspondence/confirmation/:uuid' => 'correspondence#confirmation', as: 'correspondence_confirmation'
 
-get '/feedback' => 'feedback#new'
 get '/accessibility' => 'pages#accessibility'
 
 get 'ping',           to: 'heartbeat#ping', format: :json

--- a/spec/features/send_feedback_spec.rb
+++ b/spec/features/send_feedback_spec.rb
@@ -7,13 +7,13 @@ feature 'Submit service feedback' do
     given(:comment)       { Faker::Lorem.paragraphs[1] }
 
   scenario 'Using valid inputs' do
-    visit 'feedback/new'
+    visit feedback_path
     choose 'feedback_ease_of_use_' + ease_of_use
     choose 'feedback_completeness_' + completeness
     fill_in 'feedback[comment]', with: comment
     click_button 'Send'
 
-    expect(current_path).to eq '/feedback'
+    expect(current_path).to eq feedback_path
     expect(page).to have_content('Your feedback has been sent')
 
     feedback = Feedback.last
@@ -29,10 +29,10 @@ feature 'Submit service feedback' do
   end
 
   scenario 'Without a rating for ease of use or completeness' do
-    visit 'feedback/new'
+    visit feedback_path
     click_button 'Send'
     expect(page).to have_content("This online service was easy to use please select one option")
-    expect(page).to have_content("The online serice enabled me to give all the relevant information please select one option")
+    expect(page).to have_content("The online service enabled me to give all the relevant information please select one option")
   end
 
 end


### PR DESCRIPTION
## Description
This is an attempt to try to reduce spam received through the feedback form. We are removing the links from the accessibility page as this form doesn't belong here, but we are leaving the link in the remaining places.

Renamed the URL (as the spam bot might reuse the old URL).

Also fixed a minor typo I found in the copy.

Note: we might need to iterate on this if we find out spam is still received, but for now this is a first step.

## Self-review checklist
<!-- Action these things before requesting reviews -->
* [ ] (1) Quick stakeholder demo done OR
* [ ] (2) ...bug with before and after screenshots
* [ ] (3) Tests passing
* [ ] (4) Branch ready to be merged (not work in progress)
* [ ] (5) No superfluous changes in diff
* [ ] (6) No TODO's without new ticket numbers
* [ ] (7) PR Prefixed with ticket number e.g. `CT-7654 ...`

### Screenshots
Before:
<img width="1036" alt="Screenshot 2022-05-17 at 10 53 46" src="https://user-images.githubusercontent.com/687910/168784193-9da1681e-ebde-4180-9f5e-ab50c8486289.png">

After:
<img width="1022" alt="Screenshot 2022-05-17 at 10 53 52" src="https://user-images.githubusercontent.com/687910/168784234-e5af123c-c7a7-4d16-aa62-28a1e47370a7.png">

### Related JIRA tickets
https://dsdmoj.atlassian.net/browse/CT-4199

### Deployment
<!-- Notes about database migrations, new runtime dependencies, mitigating downtime, feature flags, etc -->

### Manual testing instructions
1. The link to the feedback form is no longer in the accessibility page.
2. The feedback form can still be accessed from the other places.
3. Feedback form works as before, despite the URL being changed.
