### PR TITLE
Update bundler and remove deprecated settings

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -55,7 +55,7 @@ references:
     run:
       name: Install bundler
       command: |
-        gem install bundler -v 2.4.13
+        gem install bundler -v 2.4.19
 
   check_bundler_version: &check_bundler_version
     run:
@@ -75,7 +75,7 @@ references:
       name: Install dependencies
       command: |
         if [ "${CIRCLE_NODE_INDEX}" == "0" ]; then
-          bundle check --path vendor/bundle || bundle install --path vendor/bundle && bundle clean
+          bundle config deployment true || bundle check || bundle install
         fi
 
   save_cache: &save_cache

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -75,7 +75,8 @@ references:
       name: Install dependencies
       command: |
         if [ "${CIRCLE_NODE_INDEX}" == "0" ]; then
-          bundle config deployment true || bundle check || bundle install
+          bundle config deployment true
+          bundle check || bundle install || bundle clean
         fi
 
   save_cache: &save_cache

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -76,7 +76,7 @@ references:
       command: |
         if [ "${CIRCLE_NODE_INDEX}" == "0" ]; then
           bundle config deployment true
-          bundle check || bundle install || bundle clean
+          bundle check || bundle install && bundle clean
         fi
 
   save_cache: &save_cache

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,10 +13,10 @@ WORKDIR /usr/src/app
 RUN apk -U upgrade
 
 COPY Gemfile* ./
-RUN gem install bundler -v 2.4.13
-RUN bundle config --global frozen 1 && \
-    bundle config --path=vendor/bundle && \
-    bundle install --without development test
+RUN gem install bundler -v 2.4.19
+RUN bundle config deployment true && \
+    bundle config without development test && \
+    bundle install --jobs 4 --retry 3
 
 COPY . .
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -527,4 +527,4 @@ RUBY VERSION
    ruby 3.2.2p53
 
 BUNDLED WITH
-   2.4.13
+   2.4.19


### PR DESCRIPTION
## Description
`--path` and `--without` are deprecated

Using `deployment` stops any changes being made to `Gemfile.lock` and installs gems to `vendor/bundle`
`without` stops gems from the specified groups being installed. We don't need development and test dependencies installed in production.

## Self-review checklist
<!-- Action these things before requesting reviews -->
* [ ] (1) Quick stakeholder demo done OR
* [ ] (2) ...bug with before and after screenshots
* [ ] (3) Tests passing
* [ ] (4) Branch ready to be merged (not work in progress)
* [ ] (5) No superfluous changes in diff
* [ ] (6) No TODO's without new ticket numbers
* [ ] (7) PR Prefixed with ticket number e.g. `CT-7654 ...`

### Screenshots
<!-- Screenshots of the new changes if appropriate -->

### Related JIRA tickets
<!-- A link or list of links to relevant issues in Jira -->

### Deployment
<!-- Notes about database migrations, new runtime dependencies, mitigating downtime, feature flags, etc -->

### Manual testing instructions
<!-- Step-by-step instructions for the reviewer to manually test the changes -->
