### PR TITLE
Send healthcheck error to sentry

### DIFF
--- a/app/controllers/heartbeat_controller.rb
+++ b/app/controllers/heartbeat_controller.rb
@@ -20,7 +20,10 @@ class HeartbeatController < ApplicationController
       sidekiq: sidekiq_alive?,
     }
 
-    status = :bad_gateway unless checks.values.all?
+    unless checks.values.all?
+      status = :bad_gateway
+      Sentry.capture_message(checks)
+    end
     render status:, json: {
       checks:,
     }

--- a/app/controllers/heartbeat_controller.rb
+++ b/app/controllers/heartbeat_controller.rb
@@ -21,7 +21,7 @@ class HeartbeatController < ApplicationController
     }
 
     unless checks.values.all?
-      status = :bad_gateway
+      status = :service_unavailable
       Sentry.capture_message(checks)
     end
     render status:, json: {

--- a/config/kubernetes/development/ingress-live.yaml
+++ b/config/kubernetes/development/ingress-live.yaml
@@ -6,6 +6,8 @@ metadata:
   annotations:
     nginx.ingress.kubernetes.io/auth-type: basic
     nginx.ingress.kubernetes.io/auth-secret: app-secrets
+    # This forces all error pages to be server from the application
+    nginx.ingress.kubernetes.io/custom-http-errors: "418"
     external-dns.alpha.kubernetes.io/set-identifier: contact-moj-ingress-contact-moj-development-green
     external-dns.alpha.kubernetes.io/aws-weight: "100"
 spec:
@@ -23,6 +25,5 @@ spec:
             backend:
               service:
                 name: contact-moj-service
-                port: 
+                port:
                   number: 3000
-                

--- a/config/kubernetes/production/ingress-live.yaml
+++ b/config/kubernetes/production/ingress-live.yaml
@@ -4,6 +4,8 @@ metadata:
   name: contact-moj-ingress
   namespace: contact-moj-production
   annotations:
+    # This forces all error pages to be server from the application
+    nginx.ingress.kubernetes.io/custom-http-errors: "418"
     external-dns.alpha.kubernetes.io/set-identifier: contact-moj-ingress-contact-moj-production-green
     external-dns.alpha.kubernetes.io/aws-weight: "100"
 spec:
@@ -21,6 +23,5 @@ spec:
             backend:
               service:
                 name: contact-moj-service
-                port: 
+                port:
                   number: 3000
-                

--- a/config/kubernetes/staging/ingress-live.yaml
+++ b/config/kubernetes/staging/ingress-live.yaml
@@ -6,6 +6,8 @@ metadata:
   annotations:
     nginx.ingress.kubernetes.io/auth-type: basic
     nginx.ingress.kubernetes.io/auth-secret: app-secrets
+    # This forces all error pages to be server from the application
+    nginx.ingress.kubernetes.io/custom-http-errors: "418"
     external-dns.alpha.kubernetes.io/set-identifier: contact-moj-ingress-contact-moj-staging-green
     external-dns.alpha.kubernetes.io/aws-weight: "100"
 spec:
@@ -23,6 +25,5 @@ spec:
             backend:
               service:
                 name: contact-moj-service
-                port: 
+                port:
                   number: 3000
-                

--- a/spec/controllers/heartbeat_controller_spec.rb
+++ b/spec/controllers/heartbeat_controller_spec.rb
@@ -59,7 +59,7 @@ RSpec.describe HeartbeatController, type: :controller do
       end
 
       it "returns status bad gateway" do
-        expect(response.status).to eq(502)
+        expect(response.status).to eq(503)
       end
 
       it "returns the expected response report" do

--- a/spec/controllers/heartbeat_controller_spec.rb
+++ b/spec/controllers/heartbeat_controller_spec.rb
@@ -67,6 +67,11 @@ RSpec.describe HeartbeatController, type: :controller do
                                                 redis: false,
                                                 sidekiq: false } }.to_json)
       end
+
+      it "sends report to Sentry" do
+        expect(Sentry).to receive(:capture_message)
+        get :healthcheck
+      end
     end
 
     context "when everything is ok" do


### PR DESCRIPTION
## Description
When the healtcheck fails, report the errors to Sentry. Also changes the status from 502 to 503.

Also updates ingress so the failing healthcheck page will be rendered. Currently 5xx errors are rendered from a custom error page outside of the application