### PR TITLE
Fix heartbeat sentry logging

### DIFF
--- a/app/controllers/heartbeat_controller.rb
+++ b/app/controllers/heartbeat_controller.rb
@@ -22,7 +22,7 @@ class HeartbeatController < ApplicationController
 
     unless checks.values.all?
       status = :service_unavailable
-      Sentry.capture_message(checks)
+      Sentry.capture_message(checks.to_s)
     end
     render status:, json: {
       checks:,

--- a/config/kubernetes/development/ingress-live.yaml
+++ b/config/kubernetes/development/ingress-live.yaml
@@ -6,8 +6,8 @@ metadata:
   annotations:
     nginx.ingress.kubernetes.io/auth-type: basic
     nginx.ingress.kubernetes.io/auth-secret: app-secrets
-    # This forces all error pages to be server from the application
-    nginx.ingress.kubernetes.io/custom-http-errors: "418"
+    # This forces all 503 error page to be served from the application
+    nginx.ingress.kubernetes.io/custom-http-errors: "503"
     external-dns.alpha.kubernetes.io/set-identifier: contact-moj-ingress-contact-moj-development-green
     external-dns.alpha.kubernetes.io/aws-weight: "100"
 spec:

--- a/config/kubernetes/production/ingress-live.yaml
+++ b/config/kubernetes/production/ingress-live.yaml
@@ -4,8 +4,8 @@ metadata:
   name: contact-moj-ingress
   namespace: contact-moj-production
   annotations:
-    # This forces all error pages to be server from the application
-    nginx.ingress.kubernetes.io/custom-http-errors: "418"
+    # This forces all 503 error page to be served from the application
+    nginx.ingress.kubernetes.io/custom-http-errors: "503"
     external-dns.alpha.kubernetes.io/set-identifier: contact-moj-ingress-contact-moj-production-green
     external-dns.alpha.kubernetes.io/aws-weight: "100"
 spec:

--- a/config/kubernetes/staging/ingress-live.yaml
+++ b/config/kubernetes/staging/ingress-live.yaml
@@ -6,8 +6,8 @@ metadata:
   annotations:
     nginx.ingress.kubernetes.io/auth-type: basic
     nginx.ingress.kubernetes.io/auth-secret: app-secrets
-    # This forces all error pages to be server from the application
-    nginx.ingress.kubernetes.io/custom-http-errors: "418"
+    # This forces all 503 error page to be served from the application
+    nginx.ingress.kubernetes.io/custom-http-errors: "503"
     external-dns.alpha.kubernetes.io/set-identifier: contact-moj-ingress-contact-moj-staging-green
     external-dns.alpha.kubernetes.io/aws-weight: "100"
 spec:

--- a/spec/controllers/heartbeat_controller_spec.rb
+++ b/spec/controllers/heartbeat_controller_spec.rb
@@ -69,7 +69,7 @@ RSpec.describe HeartbeatController, type: :controller do
       end
 
       it "sends report to Sentry" do
-        expect(Sentry).to receive(:capture_message)
+        expect(Sentry).to receive(:capture_message).with(String)
         get :healthcheck
       end
     end


### PR DESCRIPTION
## Description
Value sent to Sentry needs to be a string.

Setting nginx.ingress.kubernetes.io/custom-http-errors to "418" (https://runbooks.cloud-platform.service.justice.gov.uk/custom-default-backend.html#use-platform-level-error-page) didn't work, so trying explicitly allowing the 503 error.
