### PR TITLE
CDPT-1958 Enable modsec in non-prod namespaces

### DIFF
--- a/config/kubernetes/development/ingress-live.yaml
+++ b/config/kubernetes/development/ingress-live.yaml
@@ -8,8 +8,12 @@ metadata:
     nginx.ingress.kubernetes.io/auth-secret: app-secrets
     external-dns.alpha.kubernetes.io/set-identifier: contact-moj-ingress-contact-moj-development-green
     external-dns.alpha.kubernetes.io/aws-weight: "100"
+    nginx.ingress.kubernetes.io/enable-modsecurity: "true"
+    nginx.ingress.kubernetes.io/modsecurity-snippet: |
+      SecRuleEngine On
+      SecDefaultAction "phase:2,pass,log,tag:github_team=central-digital-product-team,tag:namespace=contact-moj-development"
 spec:
-  ingressClassName: default
+  ingressClassName: modsec
   tls:
     - hosts:
         - development.contact-moj.service.justice.gov.uk

--- a/config/kubernetes/staging/ingress-live.yaml
+++ b/config/kubernetes/staging/ingress-live.yaml
@@ -8,8 +8,11 @@ metadata:
     nginx.ingress.kubernetes.io/auth-secret: app-secrets
     external-dns.alpha.kubernetes.io/set-identifier: contact-moj-ingress-contact-moj-staging-green
     external-dns.alpha.kubernetes.io/aws-weight: "100"
+    nginx.ingress.kubernetes.io/enable-modsecurity: "true"
+    nginx.ingress.kubernetes.io/modsecurity-snippet: |
+      SecRuleEngine On
+      SecDefaultAction "phase:2,pass,log,tag:github_team=central-digital-product-team,tag:namespace=contact-moj-staging"
 spec:
-  ingressClassName: default
   tls:
     - hosts:
         - staging.contact-moj.service.justice.gov.uk


### PR DESCRIPTION
## Description
[Modsec](https://user-guide.cloud-platform.service.justice.gov.uk/documentation/networking/modsecurity.html) will stop malicious traffic going to the service.