### PR TITLE
Fix form hiding

### DIFF
--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -52,3 +52,6 @@
 @import "moj/typography";
 @import "moj/govuk_overrides";
 //@import "moj/autocomplete";
+
+.js-hidden{ display:none;visibility:hidden }
+.form-group{ float:none }


### PR DESCRIPTION
## Description
The contact form should stay hidden until the "Do you still need to contact the Ministry of Justice" question is answered.

The js-hidden style had been removed.