### PR TITLE
CDPT-2483 Check if correspondence already authenticated

### DIFF
--- a/app/controllers/correspondence_controller.rb
+++ b/app/controllers/correspondence_controller.rb
@@ -43,7 +43,7 @@ class CorrespondenceController < ApplicationController
     @correspondence = Correspondence.where(uuid: params[:uuid]).first
     if @correspondence.nil?
       not_found and return
-    else
+    elsif !@correspondence.authenticated?
       @correspondence.authenticate!
       CorrespondenceMailer.new_correspondence(@correspondence).deliver_later
     end

--- a/spec/controllers/correspondence_controller_spec.rb
+++ b/spec/controllers/correspondence_controller_spec.rb
@@ -118,7 +118,7 @@ RSpec.describe CorrespondenceController, type: :controller do
 
       it "does not update the authenticated at date" do
         get :authenticate, params: { uuid: correspondence.uuid }
-        expect(correspondence.authenticated_at).to eq authenticated_time
+        expect(correspondence.reload.authenticated_at).to eq authenticated_time
       end
 
       it "does not resend the email" do

--- a/spec/controllers/correspondence_controller_spec.rb
+++ b/spec/controllers/correspondence_controller_spec.rb
@@ -117,13 +117,13 @@ RSpec.describe CorrespondenceController, type: :controller do
       before { correspondence.authenticated_at = authenticated_time }
 
       it "does not update the authenticated at date" do
-        get :authenticate, params: { uuid: "3cc98e93-d11c-42ad-832d-f40113d3ec27" }
+        get :authenticate, params: { uuid: correspondence.uuid }
         expect(correspondence.authenticated_at).to eq authenticated_time
       end
 
       it "does not resend the email" do
-        get :authenticate, params: { uuid: "3cc98e93-d11c-42ad-832d-f40113d3ec27" }
         expect(CorrespondenceMailer).not_to receive(:new_correspondence)
+        get :authenticate, params: { uuid: correspondence.uuid }
       end
     end
   end

--- a/spec/controllers/correspondence_controller_spec.rb
+++ b/spec/controllers/correspondence_controller_spec.rb
@@ -114,7 +114,7 @@ RSpec.describe CorrespondenceController, type: :controller do
     context "when record already authenticated" do
       let(:authenticated_time) { 20.minutes.ago }
 
-      before { correspondence.authenticated_at = authenticated_time }
+      before { correspondence.update(authenticated_at: authenticated_time) }
 
       it "does not update the authenticated at date" do
         get :authenticate, params: { uuid: correspondence.uuid }

--- a/spec/controllers/correspondence_controller_spec.rb
+++ b/spec/controllers/correspondence_controller_spec.rb
@@ -117,8 +117,9 @@ RSpec.describe CorrespondenceController, type: :controller do
       before { correspondence.update(authenticated_at: authenticated_time) }
 
       it "does not update the authenticated at date" do
-        get :authenticate, params: { uuid: correspondence.uuid }
-        expect(correspondence.reload.authenticated_at).to eq authenticated_time
+        expect {
+          get :authenticate, params: { uuid: correspondence.uuid }
+        }.not_to(change { correspondence.reload.authenticated_at })
       end
 
       it "does not resend the email" do


### PR DESCRIPTION
## Description
Users have to confirm their email address by clicking a link in an email sent to their address. 
There is a bug that means an email is sent every time the link it clicked, or the page refreshed.

This change checks if the correspondence has already been authenticated so that the correspondence email will only be sent once.