### PR TITLE
CDPT-2449: Cookie consent banner

### DIFF
--- a/app/controllers/cookies_controller.rb
+++ b/app/controllers/cookies_controller.rb
@@ -1,0 +1,16 @@
+class CookiesController < ApplicationController
+  def update
+    consent = params[:consent].presence_in([ConsentCookie::ACCEPT, ConsentCookie::REJECT])
+
+    if consent.nil?
+      head :not_found and return
+    end
+
+    cookies[ConsentCookie::COOKIE_NAME] = {
+      expires: ConsentCookie::EXPIRATION,
+      value: consent,
+    }
+
+    redirect_back fallback_location: root_path, flash: { cookies_consent_updated: consent }
+  end
+end

--- a/app/controllers/cookies_controller.rb
+++ b/app/controllers/cookies_controller.rb
@@ -1,4 +1,10 @@
 class CookiesController < ApplicationController
+  include AnalyticsHelper
+
+  def show
+    @consent = analytics_consent_cookie || ConsentCookie::REJECT
+  end
+
   def update
     consent = params[:consent].presence_in([ConsentCookie::ACCEPT, ConsentCookie::REJECT])
 

--- a/app/helpers/analytics_helper.rb
+++ b/app/helpers/analytics_helper.rb
@@ -1,0 +1,9 @@
+module AnalyticsHelper
+  def analytics_consent_cookie
+    cookies[ConsentCookie::COOKIE_NAME]
+  end
+
+  def analytics_allowed?
+    analytics_consent_cookie == ConsentCookie::ACCEPT
+  end
+end

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -2,6 +2,7 @@ import { initAll } from "govuk-frontend";
 import "./moj"
 import "./modules/YesNoRadio";
 import "./modules/CharacterCount";
+import "./cookie_banner"
 
 initAll();
 moj.init();

--- a/app/javascript/cookie_banner.js
+++ b/app/javascript/cookie_banner.js
@@ -1,0 +1,12 @@
+// Hide cookie banner
+var cookieBanner = document.querySelector(".govuk-cookie-banner");
+if (cookieBanner) {
+  var hideButton = cookieBanner.querySelector('.cookie-hide-button');
+
+  if (hideButton) {
+    hideButton.addEventListener("click", function(e) {
+      e.preventDefault();
+      cookieBanner.style.display = 'none';
+    });
+  }
+}

--- a/app/models/consent_cookie.rb
+++ b/app/models/consent_cookie.rb
@@ -1,0 +1,6 @@
+module ConsentCookie
+  COOKIE_NAME = "contact_moj_cookies_consent".freeze
+  EXPIRATION = 1.year
+  ACCEPT = "accept".freeze
+  REJECT = "reject".freeze
+end

--- a/app/views/cookies/show.html.erb
+++ b/app/views/cookies/show.html.erb
@@ -1,0 +1,86 @@
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <% if flash['cookies_consent_updated'] %>
+      <%= govuk_notification_banner(title_text: "Success", success: true) do |nb|
+          nb.with_heading(text: "You've set your cookie preferences.") end %>
+    <% end %>
+    <h1 class="govuk-heading-xl">Cookies</h1>
+    <p class="govuk-body">Contact the Ministry of Justice puts small files (known as 'cookies') onto your device to collect information about how you browse the site.</p>
+    <p class="govuk-body">Cookies are used to:</p>
+    <%= govuk_list ["measure how you use the website so it can be updated and improved based on your needs"], type: :bullet %>
+
+    <p class="govuk-body">Cookies aren't used to identify you personally.</p>
+    <p class="govuk-body">You'll normally see a message on the site before we store a cookie on your device.</p>
+    <p class="govuk-body">Find out <%= govuk_link_to "how to manage cookies", "https://ico.org.uk/for-the-public/online/cookies" %> from the Information Commissioner's Office.</p>
+
+    <h2 class="govuk-heading-l">Essential cookies (strictly necessary)</h2>
+    <p class="govuk-body">We use these cookies to remember your progress on this device and your cookie consent settings.</p>
+
+
+    <%= govuk_table do |table| %>
+      <%= table.with_head do |head| %>
+        <%= head.with_row do |row| %>
+          <%= row.with_cell(text: "Name") %>
+          <%= row.with_cell(text: "Purpose") %>
+          <%= row.with_cell(text: "Expires") %>
+        <% end %>
+
+        <%= table.with_body do |body| %>
+          <%= body.with_row do |row| %>
+            <%= row.with_cell(header: true, text: ConsentCookie::COOKIE_NAME) %>
+            <%= row.with_cell(text: "Saves your cookies consent settings") %>
+            <%= row.with_cell(text: "1 year") %>
+          <% end %>
+        <% end %>
+      <% end %>
+    <% end %>
+
+    <h2 class="govuk-heading-l">Analytics cookies (optional)</h2>
+    <p class="govuk-body">We use Google Analytics software to collect information about how you use this tool. We do this to help make sure this tool is meeting the needs of its users and to help us make improvements. Google Analytics stores information about:</p>
+    <%= govuk_list ["the pages you visit",
+                    "how long you spend on each page",
+                    "how you got to the tool",
+                    "what you click on while you're visiting the site"], type: :bullet %>
+    <p class="govuk-body">We do not collect or store your personal information (for example your name or address) so this information can't be used to identify who you are.</p>
+    <p class="govuk-body">We do not allow Google to use or share our analytics data.</p>
+    <p class="govuk-body">Google Analytics sets the following cookies:</p>
+
+    <%= govuk_table do |table| %>
+      <%= table.with_head do |head| %>
+        <%= head.with_row do |row| %>
+          <%= row.with_cell(text: "Name") %>
+          <%= row.with_cell(text: "Purpose") %>
+          <%= row.with_cell(text: "Expires") %>
+        <% end %>
+
+        <%= table.with_body do |body| %>
+          <%= body.with_row do |row| %>
+            <%= row.with_cell(header: true, text: "_ga") %>
+            <%= row.with_cell(text: "Helps us count how many people visit this tool by tracking if you've visited before") %>
+            <%= row.with_cell(text: "1 week") %>
+          <% end %>
+          <%= body.with_row do |row| %>
+            <%= row.with_cell(header: true, text: "_gid") %>
+            <%= row.with_cell(text: "Helps us count how many people visit this tool by tracking if you've visited before") %>
+            <%= row.with_cell(text: "24 hours") %>
+          <% end %>
+          <%= body.with_row do |row| %>
+            <%= row.with_cell(header: true, text: "_gat") %>
+            <%= row.with_cell(text: "Used to manage the rate at which page view requests are made") %>
+            <%= row.with_cell(text: "1 minute") %>
+          <% end %>
+        <% end %>
+      <% end %>
+    <% end %>
+
+    <h2 class="govuk-heading-m">Change your cookie settings</h2>
+
+    <%= form_with url: cookies_path, method: :patch do |f| %>
+      <%= f.govuk_radio_buttons_fieldset :consent, legend: { text: "Do you want to accept analytics cookies?" } do %>
+        <%= f.govuk_radio_button :consent, ConsentCookie::ACCEPT, label: { text: 'Yes' }, checked: @consent == ConsentCookie::ACCEPT %>
+        <%= f.govuk_radio_button :consent, ConsentCookie::REJECT, label: { text: 'No' }, checked: @consent == ConsentCookie::REJECT %>
+      <% end %>
+      <%= f.govuk_submit "Save cookie settings" %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/layouts/_cookie_banner.html.erb
+++ b/app/views/layouts/_cookie_banner.html.erb
@@ -1,0 +1,15 @@
+<%= govuk_cookie_banner do |cb| %>
+  <% cb.with_message(heading_text: t("cookies.heading")) do |m| %>
+    <% m.with_action { govuk_button_link_to(t("button.cookies.accept"), "/cookies/accept") } %>
+    <% m.with_action { govuk_button_link_to(t("button.cookies.reject"), "/cookies/reject") } %>
+    <% m.with_action { govuk_link_to("View cookies", "/cookies") } %>
+
+    <p class="govuk-body">
+      We use some essential cookies to make this service work.
+    </p>
+    <p class="govuk-body">
+      We'd also like to use analytics cookies so we can understand
+      how you use the service and make improvements.
+    </p>
+  <% end %>
+<% end %>

--- a/app/views/layouts/_cookie_banner.html.erb
+++ b/app/views/layouts/_cookie_banner.html.erb
@@ -2,7 +2,7 @@
   <% cb.with_message(heading_text: t("cookies.heading")) do |m| %>
     <% m.with_action { govuk_button_link_to(t("button.cookies.accept"), "/cookies/accept") } %>
     <% m.with_action { govuk_button_link_to(t("button.cookies.reject"), "/cookies/reject") } %>
-    <% m.with_action { govuk_link_to("View cookies", "/cookies") } %>
+    <% m.with_action { govuk_link_to("View cookies", cookies_path, method: "get") } %>
 
     <p class="govuk-body">
       We use some essential cookies to make this service work.

--- a/app/views/layouts/_cookie_banner_confirmation.html.erb
+++ b/app/views/layouts/_cookie_banner_confirmation.html.erb
@@ -4,7 +4,7 @@
 
     <p class="govuk-body">
       <%= t "cookies.result.#{result}" %>
-      You can <%= govuk_link_to "change your cookie settings", "/cookies" %> at any time.
+      You can <%= govuk_link_to "change your cookie settings", cookies_path, method: "get" %> at any time.
     </p>
   <% end %>
 <% end %>

--- a/app/views/layouts/_cookie_banner_confirmation.html.erb
+++ b/app/views/layouts/_cookie_banner_confirmation.html.erb
@@ -1,0 +1,10 @@
+<%= govuk_cookie_banner do |cb| %>
+  <% cb.with_message(heading_text: t("cookies.heading")) do |m| %>
+    <% m.with_action { govuk_button_link_to("Hide this message", "/", class: "cookie-hide-button") } %>
+
+    <p class="govuk-body">
+      <%= t "cookies.result.#{result}" %>
+      You can <%= govuk_link_to "change your cookie settings", "/cookies" %> at any time.
+    </p>
+  <% end %>
+<% end %>

--- a/app/views/layouts/_gtm.html.erb
+++ b/app/views/layouts/_gtm.html.erb
@@ -1,0 +1,7 @@
+<!-- Google Tag Manager -->
+<script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+})(window,document,'script','dataLayer','GTM-KRXKQFL');</script>
+<!-- End Google Tag Manager -->

--- a/app/views/layouts/_gtm_noscript.html.erb
+++ b/app/views/layouts/_gtm_noscript.html.erb
@@ -1,0 +1,4 @@
+<!-- Google Tag Manager (noscript) -->
+<noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-KRXKQFL"
+height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+<!-- End Google Tag Manager (noscript) -->

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -46,6 +46,7 @@
     </div>
 
     <%= govuk_footer(meta_items_title: "Support links", meta_items: {
+      t("common.cookies") => cookies_path, method: "get",
       t("common.accessibility") => "/accessibility" }) %>
   </body>
 </html>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -16,13 +16,7 @@
 
     <%= stylesheet_link_tag "application" %>
 
-    <!-- Google Tag Manager -->
-    <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
-    new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
-    j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
-    'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-    })(window,document,'script','dataLayer','GTM-KRXKQFL');</script>
-    <!-- End Google Tag Manager -->
+    <%= render partial: 'layouts/gtm' if analytics_allowed? %>
     <%= javascript_include_tag "application", "data-turbo-track": "reload", type: "module" %>
   </head>
 
@@ -31,11 +25,16 @@
       document.body.className = ((document.body.className) ? document.body.className + ' js-enabled' : 'js-enabled');
     </script>
 
-    <!-- Google Tag Manager (noscript) -->
-    <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-KRXKQFL"
-    height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
-    <!-- End Google Tag Manager (noscript) -->
+    <%= render partial: 'layouts/gtm_noscript' if analytics_allowed? %>
 
+    <% unless analytics_consent_cookie.present? %>
+      <%= render partial: 'layouts/cookie_banner' %>
+    <% end %>
+
+    <% if flash['cookies_consent_updated'] %>
+      <%= render partial: 'layouts/cookie_banner_confirmation', locals: { result: flash['cookies_consent_updated'] } %>
+    <% end %>
+    
     <%= govuk_skip_link %>
 
     <%= govuk_header(homepage_url: "https://www.gov.uk", service_name: t('common.service_name')) %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -46,7 +46,7 @@
     </div>
 
     <%= govuk_footer(meta_items_title: "Support links", meta_items: {
-      t("common.cookies") => cookies_path, method: "get",
+      t("common.cookies") => cookies_path,
       t("common.accessibility") => "/accessibility" }) %>
   </body>
 </html>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -65,6 +65,7 @@ en:
 
   common:
     accessibility: Accessibility
+    cookies: Cookies
     alert_banner: "We are unable to respond to documents sent by post because of coronavirus (COVID-19). When using this online contact form please be aware that responses will take longer than usual."
     service_name: Contact the Ministry of Justice
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -59,11 +59,20 @@ en:
     send: Send
     start: Start now
     continue: Continue
+    cookies:
+      accept: Accept analytics cookies
+      reject: Reject analytics cookies
 
   common:
     accessibility: Accessibility
     alert_banner: "We are unable to respond to documents sent by post because of coronavirus (COVID-19). When using this online contact form please be aware that responses will take longer than usual."
     service_name: Contact the Ministry of Justice
+
+  cookies:
+    heading: Cookies on Contact the Ministry of Justice
+    result:
+      accept: You've accepted analytics cookies.
+      reject: You've rejected analytics cookies.
 
   correspondence:
     feedback:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,6 +4,8 @@ Rails.application.routes.draw do
   resources :feedback, only: %i[new create], path: "give-feedback", path_names: { new: "" }
   get "/give-feedback" => "feedback#new", as: "feedback"
 
+  get "/cookies/:consent", to: "cookies#update"
+
   get "/correspondence" => "correspondence#topic"
   get "/correspondence/topic" => "correspondence#topic"
   get "/correspondence/search" => "correspondence#search"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,6 +5,7 @@ Rails.application.routes.draw do
   get "/give-feedback" => "feedback#new", as: "feedback"
 
   get "/cookies/:consent", to: "cookies#update"
+  resource :cookies, only: %i[show update]
 
   get "/correspondence" => "correspondence#topic"
   get "/correspondence/topic" => "correspondence#topic"

--- a/spec/controllers/cookies_controller_spec.rb
+++ b/spec/controllers/cookies_controller_spec.rb
@@ -1,0 +1,36 @@
+require "rails_helper"
+
+RSpec.describe CookiesController, type: :controller do
+  describe "GET update" do
+    context "when cookies are accepted" do
+      it "sets consent to 'accept'" do
+        get :update, params: { consent: "accept" }
+        expect(cookies[:contact_moj_cookies_consent]).to eq "accept"
+      end
+
+      it "redirects to fallback path" do
+        response = get :update, params: { consent: "accept" }
+        expect(response).to redirect_to root_path
+      end
+    end
+
+    context "when cookies are rejected" do
+      it "sets consent to 'reject'" do
+        get :update, params: { consent: "reject" }
+        expect(cookies[:contact_moj_cookies_consent]).to eq "reject"
+      end
+
+      it "redirects to fallback path" do
+        response = get :update, params: { consent: "reject" }
+        expect(response).to redirect_to root_path
+      end
+    end
+
+    context "when consent is invalid" do
+      it "does not set the cookie" do
+        get :update, params: { consent: "invalid" }
+        expect(cookies[:contact_moj_cookies_consent]).to be_nil
+      end
+    end
+  end
+end

--- a/spec/features/cookie_banner_spec.rb
+++ b/spec/features/cookie_banner_spec.rb
@@ -1,0 +1,36 @@
+require "rails_helper"
+
+RSpec.feature "CookieBanner", type: :feature do
+  before do
+    visit "/"
+  end
+
+  scenario "User sees the cookie banner on the homepage" do
+    expect(page).to have_content("We use some essential cookies to make this service work.")
+  end
+
+  scenario "User accepts analytics cookies" do
+    expect(page).to have_content("We use some essential cookies to make this service work.")
+    click_link "Accept analytics cookies"
+    expect(page).not_to have_content("We use some essential cookies to make this service work.")
+    expect(page).to have_content("You've accepted analytics cookies.")
+  end
+
+  scenario "User rejects analytics cookies" do
+    expect(page).to have_content("We use some essential cookies to make this service work.")
+    click_link "Reject analytics cookies"
+    expect(page).not_to have_content("We use some essential cookies to make this service work.")
+    expect(page).to have_content("You've rejected analytics cookies. You can change your cookie settings at any time.")
+  end
+
+  scenario "User accepts and hides cookie banner mid service", :js do
+    expect(page).to have_content("We use some essential cookies to make this service work.")
+    click_link "Start now"
+    fill_in "correspondence-topic-field", with: "Abcde"
+    click_button "Continue"
+    click_link "Accept analytics cookies"
+    click_link "Hide this message"
+    expect(page).not_to have_content("Cookies on Contact the Ministry of Justice")
+    expect(page).to have_content("You're contacting the Ministry of Justice about")
+  end
+end

--- a/spec/features/cookie_page_spec.rb
+++ b/spec/features/cookie_page_spec.rb
@@ -1,0 +1,29 @@
+require "rails_helper"
+
+RSpec.feature "Cookies page", type: :feature do
+  before do
+    visit "/cookies"
+  end
+
+  scenario "User does not want to accept analytics cookies" do
+    choose "No"
+    click_button "Save cookie settings"
+    expect(page).not_to have_content("We use some essential cookies to make this service work.")
+    expect(page).to have_content("You've rejected analytics cookies. You can change your cookie settings at any time.")
+    expect(page).to have_css(".govuk-notification-banner--success")
+    within(".govuk-form-group") do
+      expect(page).to have_checked_field("consent-reject-field")
+    end
+  end
+
+  scenario "User wants to accept analytics cookies" do
+    choose "Yes"
+    click_button "Save cookie settings"
+    expect(page).not_to have_content("We use some essential cookies to make this service work.")
+    expect(page).to have_content("You've accepted analytics cookies.")
+    expect(page).to have_css(".govuk-notification-banner--success")
+    within(".govuk-form-group") do
+      expect(page).to have_checked_field("consent-accept-field")
+    end
+  end
+end


### PR DESCRIPTION
## Description

Adds a cookie banner to Contact MoJ service. 

~~Found a small bug with some of the javascript when working on this, which I'll fix in another PR. This bug prevents JS from running on pages without the max character count.~~ fix now in main

~~The link to 'View cookies' currently does not work because the cookie page needs to be created. That PR will be based off this one.~~ Cookie page PR has been merged into this one so this is now a standalone piece of work.

## Self-review checklist
<!-- Action these things before requesting reviews -->
* [ ] (1) Quick stakeholder demo done OR
* [ ] (2) ...bug with before and after screenshots
* [x] (3) Tests passing
* [x] (4) Branch ready to be merged (not work in progress)
* [x] (5) No superfluous changes in diff
* [x] (6) No TODO's without new ticket numbers
* [x] (7) PR Prefixed with ticket number e.g. `CT-7654 ...`

### Screenshots

![Screenshot 2025-02-13 at 08 58 28](https://github.com/user-attachments/assets/40f4587a-469e-484f-aad3-7be5351b7a92)
![Screenshot 2025-02-13 at 08 58 37](https://github.com/user-attachments/assets/80b43cfe-a097-4fdc-8be8-ee6b9a57db30)

### Related JIRA tickets

https://dsdmoj.atlassian.net/browse/CDPT-2449

### Deployment

~~Will need to be merged together with the cookie page.~~ Cookie page added to this PR

### Manual testing instructions

For UI testing:
- open a browser on the homepage
- observe banner
- accept or reject cookies
- observer confirmation banner
- click on hide and observe hide behaviour
- clear cookies in the dev tools (or run an incognito browser) to observe and interact with the banner again