### PR TITLE
CDPTKAN-529 Follow up call to action when "no"

### DIFF
--- a/app/views/correspondence/_feedback.html.erb
+++ b/app/views/correspondence/_feedback.html.erb
@@ -1,3 +1,7 @@
-<%= t('.prompt') %>
-<%= govuk_link_to t('.link'), t('.link_address') %>
-<%= t('.time') %>
+<h2 class="govuk-heading-m"><%= t('.heading') %></h2>
+<p class="govuk-body"><%= t('.sub_heading') %></p>
+<ul class="govuk-list">
+  <li><%= govuk_link_to t('.start_again'), root_path %></li>
+  <li><%= govuk_link_to t('.give_feedback'), t('.link_address') %></li>
+  <li><%= govuk_link_to t('.moj_home'), Settings.moj_home_page %></li>
+</ul>

--- a/app/views/correspondence/authenticate.html.erb
+++ b/app/views/correspondence/authenticate.html.erb
@@ -10,10 +10,6 @@
     <p><%= t('.reply_timescale') %></p>
 
     <p>
-      <%= render partial: 'feedback' %>
-    </p>
-
-    <p>
       <%= govuk_link_to t('button.moj_home'), Settings.moj_home_page %>
     </p>
 

--- a/app/views/correspondence/search.html.erb
+++ b/app/views/correspondence/search.html.erb
@@ -21,9 +21,9 @@
         <% end %>
         <%= render partial: 'contact_form', locals: {f: f, klass: "js-hidden"} %>
 
-        <p id="correspondence_contact_requested_no_content" class="js-hidden">
+        <div id="correspondence_contact_requested_no_content" class="js-hidden">
           <%= render partial: 'feedback' %>
-        </p>
+        </div>
       <% else %>
         <%= render partial: 'contact_form', locals: {f: f} %>
       <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -77,10 +77,12 @@ en:
 
   correspondence:
     feedback:
-      prompt: Was this service helpful?
-      link: Provide feedback
-      time: (takes 30 seconds)
+      heading: Thank you for using this service
+      sub_heading: "You are free to close this window or do something else:"
+      start_again: Start again with a new reason for contacting MoJ
+      give_feedback: Give feedback on this service (takes 30 seconds)
       link_address: https://www.smartsurvey.co.uk/s/SU2UAX/
+      moj_home: Return to the Ministry of Justice home page
     confirmation:
       one_more_step: One more step...
       next_copy_html: |

--- a/spec/features/send_correspondence_spec.rb
+++ b/spec/features/send_correspondence_spec.rb
@@ -55,6 +55,25 @@ feature "Submit a general enquiry" do
     expect(search_page.self_service_ga_events.size).to eq 4
   end
 
+  scenario "Selecting 'No' shows content with next step links", :js do
+    topic_page.load
+    topic_page.search_govuk(topic_with_results)
+
+    expect(search_page).to be_displayed
+    expect(search_page).to have_self_serviced_radio
+
+    search_page.self_serviced_radio.click
+    search_page.wait_until_self_serviced_radio_copy_visible
+
+    no_content = search_page.self_serviced_radio_copy
+
+    expect(no_content).to have_content("Thank you for using this service")
+    expect(no_content).to have_content("You are free to close this window or do something else:")
+    expect(no_content).to have_link("Start again with a new reason for contacting MoJ", href: "/")
+    expect(no_content).to have_link("Give feedback on this service (takes 30 seconds)", href: "https://www.smartsurvey.co.uk/s/SU2UAX/")
+    expect(no_content).to have_link("Return to the Ministry of Justice home page", href: "https://www.gov.uk/government/organisations/ministry-of-justice")
+  end
+
   scenario "Using valid inputs", :js do
     topic_page.load
     expect(topic_page.title).to eq "Topic search - Contact the Ministry of Justice"

--- a/spec/site_prism/pages/correspondence/search_page.rb
+++ b/spec/site_prism/pages/correspondence/search_page.rb
@@ -4,7 +4,7 @@ module AskTool
       class SearchPage < SitePrism::Page
         set_url "/correspondence/search"
 
-        elements :self_service, "ul.govuk-list li"
+        elements :self_service, "ul.govuk-list.search-results li"
         elements :self_service_ga_events, "ul.govuk-list li a[onclick]"
         element :self_serviced_radio, 'label[for="correspondence-contact-requested-no-field"]'
         element :self_serviced_radio_copy, "#correspondence_contact_requested_no_content"


### PR DESCRIPTION
## Description
Update the call to action when a user selects "no". Word doc in Jira ticket contains new content requirements. 

## Self-review checklist
<!-- Action these things before requesting reviews -->
* [ ] (1) Quick stakeholder demo done OR
* [ ] (2) ...bug with before and after screenshots
* [ ] (3) Tests passing
* [ ] (4) Branch ready to be merged (not work in progress)
* [ ] (5) No superfluous changes in diff
* [ ] (6) No TODO's without new ticket numbers
* [ ] (7) PR Prefixed with ticket number e.g. `CT-7654 ...`

### Screenshots
Before
<img width="661" height="634" alt="Screenshot 2026-06-11 at 09 58 30" src="https://github.com/user-attachments/assets/76f0caa3-5195-4309-8dd0-6eaa0075bbd3" />

After
<img width="646" height="759" alt="Screenshot 2026-06-11 at 09 50 08" src="https://github.com/user-attachments/assets/3d11c76e-f599-43db-a635-43c9f2faef54" />


### Related JIRA tickets
https://dsdmoj.atlassian.net/jira/software/projects/CDPTKAN/boards/6617?jql=assignee%20%3D%20712020%3A3d805bbe-8fa6-48b0-b8bd-f2d3612405d6&selectedIssue=CDPTKAN-529

### Deployment
<!-- Notes about database migrations, new runtime dependencies, mitigating downtime, feature flags, etc -->

### Manual testing instructions
<!-- Step-by-step instructions for the reviewer to manually test the changes -->
