### PR TITLE
CDPTKAN-636 CT: Upgrade sidekiq from 7.3.8 to 8.1.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,7 +17,7 @@ gem "pg", "~> 1.5"
 gem "rails", "8.1.3"
 gem "responders", "~> 3.1"
 gem "sentry-sidekiq"
-gem "sidekiq", "~> 6.5"
+gem "sidekiq", "~> 8.1"
 gem "slim-rails", "~> 3.7"
 # Used for the GOVUK Search API
 gem "stopwords-filter2", require: "stopwords"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -103,11 +103,11 @@ GEM
       regexp_parser (>= 1.5, < 3.0)
       xpath (~> 3.2)
     coderay (1.1.3)
-    concurrent-ruby (1.3.6)
+    concurrent-ruby (1.3.7)
     config (5.6.1)
       deep_merge (~> 1.2, >= 1.2.1)
       ostruct
-    connection_pool (2.5.5)
+    connection_pool (3.0.2)
     crass (1.0.6)
     cssbundling-rails (1.4.3)
       railties (>= 6.0.0)
@@ -199,7 +199,7 @@ GEM
       reline (>= 0.4.2)
     jsbundling-rails (1.3.1)
       railties (>= 6.0.0)
-    json (2.19.7)
+    json (2.20.0)
     jsonb_accessor (1.4.2)
       activerecord (>= 6.1)
       activesupport (>= 6.1)
@@ -452,16 +452,16 @@ GEM
     puma (8.0.2)
       nio4r (~> 2.0)
     racc (1.8.1)
-    rack (2.2.23)
+    rack (3.2.6)
     rack-proxy (0.8.2)
       rack
-    rack-session (1.0.2)
-      rack (< 3)
+    rack-session (2.1.2)
+      base64 (>= 0.1.0)
+      rack (>= 3.0.0)
     rack-test (2.2.0)
       rack (>= 1.3)
-    rackup (1.0.1)
-      rack (< 3)
-      webrick
+    rackup (2.3.1)
+      rack (>= 3)
     rails (8.1.3)
       actioncable (= 8.1.3)
       actionmailbox (= 8.1.3)
@@ -505,7 +505,8 @@ GEM
       erb
       psych (>= 4.0.0)
       tsort
-    redis (4.8.1)
+    redis-client (0.30.0)
+      connection_pool
     regexp_parser (2.12.0)
     reline (0.6.3)
       io-console (~> 0.5)
@@ -582,19 +583,21 @@ GEM
     sentry-rails (6.6.0)
       railties (>= 5.2.0)
       sentry-ruby (~> 6.6.0)
-    sentry-ruby (6.6.0)
+    sentry-ruby (6.6.2)
       bigdecimal
       concurrent-ruby (~> 1.0, >= 1.0.2)
       logger
-    sentry-sidekiq (6.6.0)
-      sentry-ruby (~> 6.6.0)
+    sentry-sidekiq (6.6.2)
+      sentry-ruby (~> 6.6.2)
       sidekiq (>= 5.0)
     shoulda-matchers (7.0.1)
       activesupport (>= 7.1)
-    sidekiq (6.5.12)
-      connection_pool (>= 2.2.5, < 3)
-      rack (~> 2.0)
-      redis (>= 4.5.0, < 5)
+    sidekiq (8.1.6)
+      connection_pool (>= 3.0.0)
+      json (>= 2.16.0)
+      logger (>= 1.7.0)
+      rack (>= 3.2.0)
+      redis-client (>= 0.29.0)
     simplecov (0.22.0)
       docile (~> 1.1)
       simplecov-html (~> 0.11)
@@ -696,7 +699,7 @@ DEPENDENCIES
   selenium-webdriver
   sentry-sidekiq
   shoulda-matchers
-  sidekiq (~> 6.5)
+  sidekiq (~> 8.1)
   simplecov
   site_prism (~> 5.1)
   slim-rails (~> 3.7)

--- a/app/controllers/correspondence_controller.rb
+++ b/app/controllers/correspondence_controller.rb
@@ -1,5 +1,5 @@
 class CorrespondenceController < ApplicationController
-  rescue_from Redis::CannotConnectError do
+  rescue_from RedisClient::CannotConnectError do
     internal_server_error
   end
 

--- a/app/controllers/heartbeat_controller.rb
+++ b/app/controllers/heartbeat_controller.rb
@@ -34,7 +34,7 @@ class HeartbeatController < ApplicationController
 private
 
   def redis_alive?
-    Sidekiq.redis(&:info)
+    Sidekiq.redis { |conn| conn.call("INFO") }
     true
   rescue StandardError => e
     log_unknown_error(e)

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -1,7 +1,3 @@
-Sidekiq.configure_client do |config|
-  config.redis = { size: 1 }
-end
-
 Sidekiq.configure_server do |config|
   config.on :startup do
     require "prometheus_exporter/instrumentation"

--- a/spec/controllers/correspondence_controller_spec.rb
+++ b/spec/controllers/correspondence_controller_spec.rb
@@ -188,7 +188,7 @@ RSpec.describe CorrespondenceController, type: :controller do
       before do
         allow(ConfirmationMailer)
           .to receive(:new_confirmation)
-          .and_raise(Redis::CannotConnectError)
+          .and_raise(RedisClient::CannotConnectError)
         post :create, params:
       end
 

--- a/spec/controllers/heartbeat_controller_spec.rb
+++ b/spec/controllers/heartbeat_controller_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe HeartbeatController, type: :controller do
             .to receive(:new).and_return(instance_double(Sidekiq::ProcessSet, size: 0))
 
         connection = double("connection") # rubocop:disable RSpec/VerifiedDoubles
-        allow(connection).to receive(:info).and_raise(Redis::CannotConnectError)
+        allow(connection).to receive(:call).with("INFO").and_raise(RedisClient::CannotConnectError)
         allow(Sidekiq).to receive(:redis).and_yield(connection)
 
         get :healthcheck
@@ -72,7 +72,8 @@ RSpec.describe HeartbeatController, type: :controller do
       before do
         allow(ActiveRecord::Base.connection).to receive(:execute).and_return(true)
 
-        connection = double("connection", info: {}) # rubocop:disable RSpec/VerifiedDoubles
+        connection = double("connection") # rubocop:disable RSpec/VerifiedDoubles
+        allow(connection).to receive(:call).with("INFO")
         allow(Sidekiq).to receive(:redis).and_yield(connection)
 
         get :healthcheck


### PR DESCRIPTION
## Description
Upgrades Sidekiq to 8.1.6 (latest). Sidekiq 8 drops the redis gem in favour of redis-client and removes the Sidekiq.configure_client API

## Self-review checklist
<!-- Action these things before requesting reviews -->
* [ ] (1) Quick stakeholder demo done OR
* [x] (2) ...bug with before and after screenshots
* [x] (3) Tests passing
* [x] (4) Branch ready to be merged (not work in progress)
* [x] (5) No superfluous changes in diff
* [x] (6) No TODO's without new ticket numbers
* [x] (7) PR Prefixed with ticket number e.g. `CT-7654 ...`

### Screenshots
<!-- Screenshots of the new changes if appropriate -->

### Related JIRA tickets
<!-- A link or list of links to relevant issues in Jira -->

### Deployment
<!-- Notes about database migrations, new runtime dependencies, mitigating downtime, feature flags, etc -->

### Manual testing instructions
<!-- Step-by-step instructions for the reviewer to manually test the changes -->
