### PR TITLE
CDPTKAN-1225 Contact MoJ: Clean up brakeman.ignore file

### DIFF
--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -1,25 +1,6 @@
 {
   "ignored_warnings": [
-    {
-      "warning_type": "Cross Site Scripting",
-      "warning_code": 4,
-      "fingerprint": "f56780e9986e10e79f21fad848034ee1738b7ca65845152199fbf0013b355d57",
-      "check_name": "LinkToHref",
-      "message": "Unsafe model attribute in link_to href",
-      "file": "app/views/correspondence/search.html.slim",
-      "line": 24,
-      "link": "http://brakemanscanner.org/docs/warning_types/link_to_href",
-      "code": "link_to(t(\".more_results\"), escape_once(GovUkSearchApi::Client.new(Correspondence.new(correspondence_params).topic).more_results_url))",
-      "render_path": [{"type":"controller","class":"CorrespondenceController","method":"create","line":22,"file":"app/controllers/correspondence_controller.rb"}],
-      "location": {
-        "type": "template",
-        "template": "correspondence/search"
-      },
-      "user_input": "Correspondence.new(correspondence_params)",
-      "confidence": "Medium",
-      "note": ""
-    }
   ],
-  "updated": "2017-02-21 12:34:40 +0000",
-  "brakeman_version": "3.5.0"
+  "updated": "2026-07-15 00:00:00 +0000",
+  "brakeman_version": "8.0.4"
 }


### PR DESCRIPTION
## Description
  Removes a stale Brakeman ignore entry that has been in the file since 2017.

The ignored warning referenced a LinkToHref XSS check on app/views/correspondence/search.html.slim — a view file that no longer exists in the codebase. Keeping dead ignore entries obscures the true security posture of the app and could mask future real warnings being silently ignored.                                                                          
                

## Self-review checklist
<!-- Action these things before requesting reviews -->
* [ ] (1) Quick stakeholder demo done OR
* [ ] (2) ...bug with before and after screenshots
* [ ] (3) Tests passing
* [ ] (4) Branch ready to be merged (not work in progress)
* [ ] (5) No superfluous changes in diff
* [ ] (6) No TODO's without new ticket numbers
* [ ] (7) PR Prefixed with ticket number e.g. `CT-7654 ...`

### Screenshots
<!-- Screenshots of the new changes if appropriate -->

### Related JIRA tickets
https://dsdmoj.atlassian.net/browse/CDPTKAN-1225

### Deployment
<!-- Notes about database migrations, new runtime dependencies, mitigating downtime, feature flags, etc -->

### Manual testing instructions
<!-- Step-by-step instructions for the reviewer to manually test the changes -->
