### PR TITLE
CDPTKAN-1222: Re-enables force_ssl in the production Rails environment,

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -48,7 +48,7 @@ Rails.application.configure do
   # config.action_cable.allowed_request_origins = [ 'http://example.com', /http:\/\/example.*/ ]
 
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
-  # config.force_ssl = true
+  config.force_ssl = true
 
   # Include generic and useful information about system operation, but avoid logging too much
   # information to avoid inadvertent exposure of personally identifiable information (PII).


### PR DESCRIPTION
## Description
  Re-enables force_ssl in the production Rails environment, which had been commented out.                                                                                            
                                                                                                                                                                                     
  Setting `config.force_ssl = true` enforces:                                                                                                                                          
  - All HTTP requests are redirected to HTTPS                                                                                                                                        
  - Strict-Transport-Security (HSTS) header is set                                                                                                                                   
  - Session cookies are marked Secure

## Self-review checklist
<!-- Action these things before requesting reviews -->
* [ ] (1) Quick stakeholder demo done OR
* [ ] (2) ...bug with before and after screenshots
* [ ] (3) Tests passing
* [ ] (4) Branch ready to be merged (not work in progress)
* [ ] (5) No superfluous changes in diff
* [ ] (6) No TODO's without new ticket numbers
* [ ] (7) PR Prefixed with ticket number e.g. `CT-7654 ...`

### Screenshots
<!-- Screenshots of the new changes if appropriate -->

### Related JIRA tickets
https://dsdmoj.atlassian.net/browse/CDPTKAN-1222

### Deployment
<!-- Notes about database migrations, new runtime dependencies, mitigating downtime, feature flags, etc -->

### Manual testing instructions
<!-- Step-by-step instructions for the reviewer to manually test the changes -->
