### PR TITLE
[NO TICKET] Fix prometheus exporter conn refused

### DIFF
--- a/config/initializers/prometheus_exporter.rb
+++ b/config/initializers/prometheus_exporter.rb
@@ -22,3 +22,15 @@ unless Rails.env.test? || Rails.env.development?
     end
   end
 end
+
+# Locally there's no metrics sidecar on port 9394, so Prometheus clients log
+# repeated "Connection refused" errors. Start the exporter in-process for
+# development only to give them a collector and silence those errors.
+#
+# Once running, metrics are available at http://localhost:9394/metrics
+#
+# Source: https://www.rubydoc.info/gems/govuk_app_config/9.24.1
+if Rails.env.development?
+  require "govuk_app_config/govuk_prometheus_exporter"
+  GovukPrometheusExporter.configure
+end


### PR DESCRIPTION
## Description
Running this service locally resulted in the below, unless `bundle exec prometheus_exporter` is running in a separate window. This change initialises `GovukPrometheusExporter` in development, so the local prometheus client has a port to bind to and fixes the error.

E, [2026-07-15T15:16:19.717124 #37118] ERROR -- : Prometheus Exporter, failed to send message Connection refused - connect(2) for "localhost" port 9394

## Self-review checklist
<!-- Action these things before requesting reviews -->
* [ ] (1) Quick stakeholder demo done OR
* [ ] (2) ...bug with before and after screenshots
* [ ] (3) Tests passing
* [ ] (4) Branch ready to be merged (not work in progress)
* [ ] (5) No superfluous changes in diff
* [ ] (6) No TODO's without new ticket numbers
* [ ] (7) PR Prefixed with ticket number e.g. `CT-7654 ...`

### Screenshots
<!-- Screenshots of the new changes if appropriate -->

### Related JIRA tickets
<!-- A link or list of links to relevant issues in Jira -->

### Deployment
<!-- Notes about database migrations, new runtime dependencies, mitigating downtime, feature flags, etc -->

### Manual testing instructions
<!-- Step-by-step instructions for the reviewer to manually test the changes -->
