### PR TITLE
CDPTKAN-1221  Switch on Content Security Policy

### DIFF
--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -3,3 +3,8 @@ $govuk-global-styles: true;
 @import "govuk-frontend/dist/govuk/index";
 @import "moj/layout";
 @import "moj/typography";
+
+.app-gtm-noscript-iframe {
+  display: none;
+  visibility: hidden;
+}

--- a/app/views/layouts/_gtm.html.erb
+++ b/app/views/layouts/_gtm.html.erb
@@ -1,5 +1,5 @@
 <!-- Google Tag Manager -->
-<script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+<script nonce="<%= content_security_policy_nonce %>">(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
 new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
 j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);

--- a/app/views/layouts/_gtm_noscript.html.erb
+++ b/app/views/layouts/_gtm_noscript.html.erb
@@ -1,4 +1,4 @@
 <!-- Google Tag Manager (noscript) -->
 <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-KRXKQFL"
-height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+height="0" width="0" class="app-gtm-noscript-iframe"></iframe></noscript>
 <!-- End Google Tag Manager (noscript) -->

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -21,7 +21,7 @@
   </head>
 
   <body class="govuk-template__body govuk-frontend-supported">
-    <script>
+    <script nonce="<%= content_security_policy_nonce %>">
       document.body.className = ((document.body.className) ? document.body.className + ' js-enabled' : 'js-enabled');
     </script>
 

--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -11,6 +11,6 @@ Rails.application.configure do
     policy.base_uri    :self
   end
 
-  config.content_security_policy_nonce_generator = ->(request) { SecureRandom.base64(16) }
+  config.content_security_policy_nonce_generator = ->(_request) { SecureRandom.base64(16) }
   config.content_security_policy_nonce_directives = %w[script-src]
 end

--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -1,25 +1,16 @@
-# Be sure to restart your server when you modify this file.
+Rails.application.configure do
+  config.content_security_policy do |policy|
+    policy.default_src :self
+    policy.font_src    :self
+    policy.img_src     :self, :data
+    policy.object_src  :none
+    policy.script_src  :self, "https://www.googletagmanager.com"
+    policy.style_src   :self
+    policy.frame_src   "https://www.googletagmanager.com"
+    policy.connect_src :self
+    policy.base_uri    :self
+  end
 
-# Define an application-wide content security policy.
-# See the Securing Rails Applications Guide for more information:
-# https://guides.rubyonrails.org/security.html#content-security-policy-header
-
-# Rails.application.configure do
-#   config.content_security_policy do |policy|
-#     policy.default_src :self, :https
-#     policy.font_src    :self, :https, :data
-#     policy.img_src     :self, :https, :data
-#     policy.object_src  :none
-#     policy.script_src  :self, :https
-#     policy.style_src   :self, :https
-#     # Specify URI for violation reports
-#     # policy.report_uri "/csp-violation-report-endpoint"
-#   end
-#
-#   # Generate session nonces for permitted importmap, inline scripts, and inline styles.
-#   config.content_security_policy_nonce_generator = ->(request) { request.session.id.to_s }
-#   config.content_security_policy_nonce_directives = %w(script-src style-src)
-#
-#   # Report violations without enforcing the policy.
-#   # config.content_security_policy_report_only = true
-# end
+  config.content_security_policy_nonce_generator = ->(request) { SecureRandom.base64(16) }
+  config.content_security_policy_nonce_directives = %w[script-src]
+end


### PR DESCRIPTION
## Description
Enables the Rails Content Security Policy (CSP) header as an XSS defence-in-depth measure. The CSP initialiser was previously commented out — this PR activates it with a policy tailored to this application's actual asset and third-party sources.

  **Policy directives:**                                                                                                                                                                 
  - default-src 'self' — safe fallback for any unspecified directive                                                                                                                 
  - script-src 'self' https://www.googletagmanager.com + per-request nonce — covers bundled JS, GTM loader, and inline scripts                                                       
  - style-src 'self' — only Sprockets-served CSS                                                                                                                                     
  - font-src 'self' — GOV.UK fonts via Sprockets                                                                                                                                     
  - img-src 'self' data: — favicons, images, and data URIs                                                                                                                           
  - object-src 'none' — blocks Flash/plugins entirely                                                                                                                                
  - frame-src https://www.googletagmanager.com — GTM noscript pixel                                                                                                                  
  - connect-src 'self' — no external XHR/fetch in the app                                                                                                                            
  - base-uri 'self' — prevents <base> tag injection                                                                                                                                  
                                                                                                                                                                                     
Nonces: A fresh SecureRandom.base64(16) nonce is generated per request and applied to script-src, with the nonce attribute added to both inline scripts (GOV.UK JS detection in the layout and the GTM loader).                                                                                                                                                        
                                                                                                                                                                                     
GTM noscript iframe: The hardcoded style="display:none;visibility:hidden" on the GTM noscript pixel iframe was replaced with a CSS class — inline style attributes are blocked by style-src 'self' without unsafe-inline.

## Self-review checklist
<!-- Action these things before requesting reviews -->
* [ ] (1) Quick stakeholder demo done OR
* [ ] (2) ...bug with before and after screenshots
* [ ] (3) Tests passing
* [ ] (4) Branch ready to be merged (not work in progress)
* [ ] (5) No superfluous changes in diff
* [ ] (6) No TODO's without new ticket numbers
* [ ] (7) PR Prefixed with ticket number e.g. `CT-7654 ...`

### Screenshots
<!-- Screenshots of the new changes if appropriate -->

### Related JIRA tickets
<!-- A link or list of links to relevant issues in Jira -->

### Deployment
https://dsdmoj.atlassian.net/browse/CDPTKAN-1221

### Manual testing instructions
<!-- Step-by-step instructions for the reviewer to manually test the changes -->
